### PR TITLE
Better Guice+Jersey integration with GuiceManagedAtmoshpereServlet

### DIFF
--- a/extras/guice/src/main/java/org/atmosphere/guice/GuiceManagedAtmoshpereServlet.java
+++ b/extras/guice/src/main/java/org/atmosphere/guice/GuiceManagedAtmoshpereServlet.java
@@ -81,7 +81,6 @@ public class GuiceManagedAtmoshpereServlet extends AtmosphereServlet {
         setUseStreamForFlushingComments(true);
 
         rsp.setServlet(guiceServlet);
-        //rsp.setFilterClassName(GUICE_FILTER);
         getAtmosphereConfig().setSupportSession(false);
 
         String mapping = sc.getInitParameter(PROPERTY_SERVLET_MAPPING);


### PR DESCRIPTION
Note: please review this file. This is a copy of the existing AtmosphereGuiceServlet, with two changes: 
- @Singleton
- Removed GuiceFIlter servlet from ReflectorServletProcessor to avoid the killer loop created when init is called

I've copied it to a more understandable name but perhaps you would prefer to take the existing one and modify it (but i really don't know how since you would have to detect that you are in a guice-managed context)

Enables to use a completely Guice-managed environment. web.xml only contains:

```
 <listener>
     <listener-class>org.company.GuiceContextListener</listener-class>
 </listener>
 <filter>
     <filter-name>Guice Filter</filter-name>
     <filter-class>com.google.inject.servlet.GuiceFilter</filter-class>
 </filter>
 <filter-mapping>
     <filter-name>Guice Filter</filter-name>
     <url-pattern>/*</url-pattern>
 </filter-mapping>
```

In our Guice config, we setup Jersey + Atmosphere like this:

```
 @Override
 protected Injector getInjector() {
     return Guice.createInjector(new ServletModule() {
         @Override
         protected void configureServlets() {
             bind(MessageResource.class);
             serve("*/async/**").with(*GuiceManagedAtmoshpereServlet*.class, new HashMap<String, String>() {
                 {
                     put("org.atmosphere.useWebSocket", "true");
                     put("org.atmosphere.useNative", "true");
                 }
             });
             serve("/*rest/**").with(*GuiceContainer*.class);
         }
     });
 } 
```
