### PR TITLE
Added `MozWebSocket` support for later Firefox browsers

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -86,7 +86,7 @@ jQuery.atmosphere = function() {
             if (jQuery.atmosphere.request.transport != 'websocket') {
                 jQuery.atmosphere.executeRequest();
             } else if (jQuery.atmosphere.request.transport == 'websocket') {
-                if (jQuery.atmosphere.request.webSocketImpl == null && !window.WebSocket) {
+                if (jQuery.atmosphere.request.webSocketImpl == null && !window.WebSocket && !window.MozWebSocket) {
                     jQuery.atmosphere.log(logLevel, ["Websocket is not supported, using request.fallbackTransport ("
                             + jQuery.atmosphere.request.fallbackTransport + ")"]);
                     jQuery.atmosphere.request.transport = jQuery.atmosphere.request.fallbackTransport;
@@ -403,7 +403,11 @@ jQuery.atmosphere = function() {
             if (jQuery.atmosphere.request.webSocketImpl != null) {
                 websocket = jQuery.atmosphere.request.webSocketImpl;
             } else {
-                websocket = new WebSocket(location);
+              if (window.WebSocket) {
+                  websocket = new WebSocket(location);
+              } else {
+                  websocket = new MozWebSocket(location);
+              }
             }
 
             jQuery.atmosphere.websocket = websocket;
@@ -525,7 +529,7 @@ jQuery.atmosphere = function() {
             if (jQuery.atmosphere.request.transport != 'websocket') {
                 jQuery.atmosphere.executeRequest();
             } else if (jQuery.atmosphere.request.transport == 'websocket') {
-                if (!window.WebSocket) {
+                if (!window.WebSocket && !window.MozWebSocket) {
                     alert("WebSocket not supported by this browser");
                 }
                 else {

--- a/samples/di-guice-sample/src/main/webapp/jquery.atmosphere.js
+++ b/samples/di-guice-sample/src/main/webapp/jquery.atmosphere.js
@@ -88,7 +88,7 @@ jQuery.atmosphere = function()
             if (jQuery.atmosphere.request.transport != 'websocket') {
                 jQuery.atmosphere.executeRequest();
             } else if (jQuery.atmosphere.request.transport == 'websocket') {
-                if (jQuery.atmosphere.request.webSocketImpl == null && !window.WebSocket) {
+                if (jQuery.atmosphere.request.webSocketImpl == null && !window.WebSocket && !window.MozWebSocket) {
                     jQuery.atmosphere.log(logLevel, ["Websocket is not supported, using request.fallbackTransport"]);
                     jQuery.atmosphere.request.transport = jQuery.atmosphere.request.fallbackTransport;
                     jQuery.atmosphere.response.transport = jQuery.atmosphere.request.fallbackTransport;
@@ -379,7 +379,11 @@ jQuery.atmosphere = function()
             if (jQuery.atmosphere.request.webSocketImpl != null) {
                 websocket = jQuery.atmosphere.request.webSocketImpl;
             } else {
-                websocket = new WebSocket(location);
+              if (window.WebSocket) {
+                  websocket = new WebSocket(location);
+              } else {
+                  websocket = new MozWebSocket(location);
+              }
             }
 
             jQuery.atmosphere.websocket = websocket;
@@ -510,7 +514,7 @@ jQuery.atmosphere = function()
             if (jQuery.atmosphere.request.transport != 'websocket') {
                 jQuery.atmosphere.executeRequest();
             } else if (jQuery.atmosphere.request.transport == 'websocket') {
-                if (!window.WebSocket) {
+                if (!window.WebSocket && !window.MozWebSocket) {
                     alert("WebSocket not supported by this browser");
                 }
                 else {


### PR DESCRIPTION
Updated atmosphere.js to work with more recent Firefox browsers that have renamed `WebSocket` as `MozWebSocket`.
