### PR TITLE
fix for issue with long-polling getting empty body

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -245,6 +245,7 @@ jQuery.atmosphere = function() {
                             request.lastIndex = responseText.length;
                             if (junkForWebkit) return;
                         } else {
+                            response.responseBody = responseText;
                             request.lastIndex = responseText.length;
                         }
 


### PR DESCRIPTION
We're having an issue where the responseBody is empty for clients using long-polling.  I've added the line that seems to make most sense to me and it fixes our issue.  Please consider adding it to the master.
