### PR TITLE
Fix for Safari closed websocket without error.

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -460,7 +460,6 @@ jQuery.atmosphere = function() {
 
             websocket.onerror = function(message) {
                 jQuery.atmosphere.warn("Websocket error, reason: " + message.reason);
-                console.log(message);
                 jQuery.atmosphere.response.state = 'error';
                 jQuery.atmosphere.invokeCallback(jQuery.atmosphere.response);
             };

--- a/samples/di-guice-sample/src/main/webapp/jquery.atmosphere.js
+++ b/samples/di-guice-sample/src/main/webapp/jquery.atmosphere.js
@@ -460,7 +460,6 @@ jQuery.atmosphere = function() {
 
             websocket.onerror = function(message) {
                 jQuery.atmosphere.warn("Websocket error, reason: " + message.reason);
-                console.log(message);
                 jQuery.atmosphere.response.state = 'error';
                 jQuery.atmosphere.invokeCallback(jQuery.atmosphere.response);
             };


### PR DESCRIPTION
Fix for Safari closed websocket without error.  Fix for log functions missing jQuery prefix.  Added some debug level logging. Fixed "openning" typo.
