### PR TITLE
Prevent IE8 error "The data necessary to complete this operation is not yet available"

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -203,7 +203,6 @@ jQuery.atmosphere = function() {
 
                     var junkForWebkit = false;
                     var update = false;
-                    var responseText = ajaxRequest.responseText;
                     if (ajaxRequest.readyState == 4) {
                         jQuery.atmosphere.request = request;
                         if (request.suspend && ajaxRequest.status == 200 && request.transport != 'streaming') {
@@ -220,7 +219,7 @@ jQuery.atmosphere = function() {
                     }
 
                     if (update) {
-
+                        var responseText = ajaxRequest.responseText;
                         this.previousLastIndex = request.lastIndex;
                         if (request.transport == 'streaming') {
                             response.responseBody = responseText.substring(request.lastIndex, responseText.length);


### PR DESCRIPTION
prevent IE8 error 'The data necessary to complete this operation is not yet available' by not getting ajaxRequest.responseText until readyState == 4 when using msie browser.
