### PR TITLE
if jersey classes are found in the classpath and atmosphere-jersey module is not include, it won't crash

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereServlet.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereServlet.java
@@ -752,8 +752,16 @@ public class AtmosphereServlet extends AbstractAsyncServlet implements CometProc
         } catch (Throwable ignored) {
         }
 
+        String broadcasterClassNameTmp = null;
+        
         try {
             cl.loadClass(JERSEY_CONTAINER);
+            
+            if (!isBroadcasterSpecified){
+                broadcasterClassNameTmp = lookupDefaultBroadcasterType();
+
+                cl.loadClass(broadcasterClassNameTmp);
+            }
             useStreamForFlushingComments = true;
         } catch (Throwable t) {
             return false;
@@ -765,7 +773,7 @@ public class AtmosphereServlet extends AbstractAsyncServlet implements CometProc
         initParams.put(WRITE_HEADERS, "false");
 
         ReflectorServletProcessor rsp = new ReflectorServletProcessor();
-        if (!isBroadcasterSpecified) broadcasterClassName = lookupDefaultBroadcasterType();
+        if (broadcasterClassNameTmp!=null) broadcasterClassName = broadcasterClassNameTmp;
         rsp.setServletClassName(JERSEY_CONTAINER);
         sessionSupport(false);
         initParams.put(DISABLE_ONSTATE_EVENT, "true");


### PR DESCRIPTION
The usecase : 

Suppose that you have a Atmosphere application in production that doesn't use Jersey and there are new developements to that application.

The new features are not releated to Atmosphere, so the code won't be touch.

In the development they had Jersey dependancies : client and core.

The side effect is that Atmopshere will detect Jersey classes in the classpath at runtime and will get a ClassNotFoundException for : org.atmosphere.jersey.JerseyBroadcaster  because the Atmosphere-jersey modules.

With that fix, if Jersey framework is detected, Atmosphere will try to load org.atmosphere.jersey.JerseyBroadcaster, but if it failed, it will consider that the Jersey framework shouldn't be used and continue to run like before.
