### PR TITLE
mvn fails to build from trunk because Config static variables were moved and certain Test classes were not updated

### DIFF
--- a/modules/cpr/src/test/java/org/atmosphere/tests/BaseTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/tests/BaseTest.java
@@ -69,6 +69,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.atmosphere.cpr.HeaderConfig.X_CACHE_DATE;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -894,7 +896,7 @@ public abstract class BaseTest {
 
             public void onRequest(AtmosphereResource<HttpServletRequest, HttpServletResponse> event) throws IOException {
                 try {
-                    if (event.getRequest().getHeader(HeaderBroadcasterCache.HEADER_CACHE) != null) {
+                    if (event.getRequest().getHeader(X_CACHE_DATE) != null) {
                         event.suspend(-1, false);
                         return;
                     }
@@ -933,7 +935,7 @@ public abstract class BaseTest {
             c.prepareGet(urlTarget).execute().get();
 
             //Suspend
-            Response r = c.prepareGet(urlTarget).addHeader(HeaderBroadcasterCache.HEADER_CACHE, String.valueOf(t1)).execute(new AsyncCompletionHandler<Response>() {
+            Response r = c.prepareGet(urlTarget).addHeader(X_CACHE_DATE, String.valueOf(t1)).execute(new AsyncCompletionHandler<Response>() {
 
                 @Override
                 public Response onCompleted(Response r) throws Exception {

--- a/modules/jersey/src/test/java/org/atmosphere/jersey/tests/BasePubSubTest.java
+++ b/modules/jersey/src/test/java/org/atmosphere/jersey/tests/BasePubSubTest.java
@@ -53,6 +53,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.atmosphere.cpr.HeaderConfig.X_CACHE_DATE;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -456,7 +458,7 @@ public abstract class BasePubSubTest extends BaseTest {
             c.preparePost(urlTarget).addParameter("message", "cachememe").execute().get();
 
             //Suspend
-            Response r = c.prepareGet(urlTarget + "/subscribeAndResume").addHeader(HeaderBroadcasterCache.HEADER_CACHE, String.valueOf(t1)).execute(new AsyncCompletionHandler<Response>() {
+            Response r = c.prepareGet(urlTarget + "/subscribeAndResume").addHeader(X_CACHE_DATE, String.valueOf(t1)).execute(new AsyncCompletionHandler<Response>() {
 
                 @Override
                 public Response onCompleted(Response r) throws Exception {

--- a/modules/jersey/src/test/java/org/atmosphere/jersey/tests/TomcatJerseyTest.java
+++ b/modules/jersey/src/test/java/org/atmosphere/jersey/tests/TomcatJerseyTest.java
@@ -52,6 +52,7 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import java.io.File;
 
+import static org.atmosphere.cpr.ApplicationConfig.MAX_INACTIVE;
 
 public class TomcatJerseyTest extends BasePubSubTest {
 
@@ -60,7 +61,7 @@ public class TomcatJerseyTest extends BasePubSubTest {
     public static class TomcatAtmosphereServlet extends AtmosphereServlet {
 
         public void init(final ServletConfig sc) throws ServletException {
-            addInitParameter(CometSupport.MAX_INACTIVE, "20000");
+            addInitParameter(MAX_INACTIVE, "20000");
             addInitParameter("com.sun.jersey.config.property.packages", this.getClass().getPackage().getName());
             addInitParameter("org.atmosphere.cpr.broadcasterClass", RecyclableBroadcaster.class.getName());
             cometSupport = new TomcatCometSupport(getAtmosphereConfig());


### PR DESCRIPTION
Hello,

I checked out the repository and saw that the build was failing due to missing static variables. I have corrected these build errors by importing the static variables from the Config files that they were moved to. Let me know if this was inappropriate.

Evan

Below is my commit message:

Properly reference static Config variables that have been moved into HeaderConfig and ApplicationConfig from test classes.
