### PR TITLE
In the websocket.onopen function: invoke the callback at the the very end

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -674,13 +674,14 @@ jQuery.atmosphere = function() {
                 jQuery.atmosphere.debug("Websocket successfully opened");
                 webSocketSupported = true;
                 jQuery.atmosphere.response.state = 'opening';
-                jQuery.atmosphere.invokeCallback(jQuery.atmosphere.response);
 
                 if (jQuery.atmosphere.request.method == 'POST') {
                     data = jQuery.atmosphere.request.data;
                     jQuery.atmosphere.response.state = 'messageReceived';
                     websocket.send(jQuery.atmosphere.request.data);
                 }
+                
+                jQuery.atmosphere.invokeCallback(jQuery.atmosphere.response);
             };
 
             websocket.onmessage = function(message) {


### PR DESCRIPTION
In the websocket.onopen function: invoke the callback at the the very end, otherwise there is a possibility that 'atmosphere variables' are changed before the function is completely executed. 
For example, when you do a atmosphere.response.push IN THAT callback (with state == 'opening' and method = 'post') it might happen that the data is send twice.
