### PR TITLE
RedisBroadcaster changes

### DIFF
--- a/extras/redis/src/main/java/org/atmosphere/plugin/redis/RedisBroadcaster.java
+++ b/extras/redis/src/main/java/org/atmosphere/plugin/redis/RedisBroadcaster.java
@@ -22,11 +22,10 @@ import org.atmosphere.util.AbstractBroadcasterProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisException;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPubSub;
+import redis.clients.jedis.exceptions.JedisException;
 
-import java.io.IOException;
 import java.net.URI;
 
 /**
@@ -107,7 +106,7 @@ public class RedisBroadcaster extends AbstractBroadcasterProxy {
         try {
             jedisSubscriber.connect();
             auth(jedisSubscriber);
-        } catch (IOException e) {
+        } catch (JedisException e) {
             logger.error("failed to connect subscriber", e);
             disconnectSubscriber();
         }
@@ -117,7 +116,7 @@ public class RedisBroadcaster extends AbstractBroadcasterProxy {
             try {
                 jedisPublisher.connect();
                 auth(jedisPublisher);
-            } catch (IOException e) {
+            } catch (JedisException e) {
                 logger.error("failed to connect publisher", e);
                 disconnectPublisher();
             }
@@ -252,7 +251,7 @@ public class RedisBroadcaster extends AbstractBroadcasterProxy {
         synchronized (jedisSubscriber) {
             try {
                 jedisSubscriber.disconnect();
-            } catch (IOException e) {
+            } catch (JedisException e) {
                 logger.error("failed to disconnect subscriber", e);
             }
         }
@@ -264,7 +263,7 @@ public class RedisBroadcaster extends AbstractBroadcasterProxy {
         synchronized (jedisPublisher) {
             try {
                 jedisPublisher.disconnect();
-            } catch (IOException e) {
+            } catch (JedisException e) {
                 logger.error("failed to disconnect publisher", e);
             }
         }

--- a/extras/redis/src/main/java/org/atmosphere/plugin/redis/RedisFilter.java
+++ b/extras/redis/src/main/java/org/atmosphere/plugin/redis/RedisFilter.java
@@ -22,8 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPubSub;
+import redis.clients.jedis.exceptions.JedisException;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
@@ -73,7 +73,7 @@ public class RedisFilter implements ClusterBroadcastFilter {
         try {
             jedisSubscriber.connect();
             auth(jedisSubscriber);
-        } catch (IOException e) {
+        } catch (JedisException e) {
             logger.error("failed to connect to subscriber: {}", jedisSubscriber, e);
         }
 
@@ -81,7 +81,7 @@ public class RedisFilter implements ClusterBroadcastFilter {
         try {
             jedisPublisher.connect();
             auth(jedisPublisher);
-        } catch (IOException e) {
+        } catch (JedisException e) {
             logger.error("failed to connect to publisher: {}", jedisPublisher, e);
         }
     }
@@ -145,7 +145,7 @@ public class RedisFilter implements ClusterBroadcastFilter {
         try {
             jedisPublisher.disconnect();
             jedisSubscriber.disconnect();
-        } catch (IOException e) {
+        } catch (JedisException e) {
             logger.error("failure encountered during destroy", e);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,7 @@
         <guice-version>2.0</guice-version>
         <wicket.version>1.4.12</wicket.version>
         <ahc.version>1.6.5</ahc.version>
-        <jedis.version>1.5.0</jedis.version>
+        <jedis.version>2.0.0</jedis.version>
         <slf4j-impl-version>1.6.1</slf4j-impl-version>
         <slf4j-version>1.6.1</slf4j-version>
         <logback-version>0.9.24</logback-version>


### PR DESCRIPTION
Cleanup of pooled logic for the RedisBroadcaster.  Notable changes:

1) If a shared pool is used, then jedisPublisher is always set to null
2) Separate logic in publisher between shared pool and not
3) Remove recursion and atomic integer from publisher
