### PR TITLE
Ensure that setID is called before the broadcast handler is executed.  O...

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
@@ -444,9 +444,9 @@ public class DefaultBroadcaster implements Broadcaster {
             broadcasterCache = bc.getBroadcasterCache();
             broadcasterCache.start();
 
+            setID(name);
             notifierFuture = bc.getExecutorService().submit(getBroadcastHandler());
             asyncWriteFuture = bc.getAsyncWriteService().submit(getAsyncWriteHandler());
-            setID(name);
         }
     }
 

--- a/modules/cpr/src/main/java/org/atmosphere/util/AbstractBroadcasterProxy.java
+++ b/modules/cpr/src/main/java/org/atmosphere/util/AbstractBroadcasterProxy.java
@@ -69,7 +69,7 @@ public abstract class AbstractBroadcasterProxy extends DefaultBroadcaster {
                 try {
                     incomingBroadcast();
                 } catch (Throwable t) {
-                    logger.trace("incomingBroadcast Exception. Broadcaster will be broken unless reconfigured", t);
+                    logger.debug("incomingBroadcast Exception. Broadcaster will be broken unless reconfigured", t);
                     destroy();
                     return;
                 }


### PR DESCRIPTION
...therwise, there is a race condition where the broadcaster may not be initialized before the executor fires.
