### PR TITLE
Fixed compile errors for jetty 7.x with javax 2.5.

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AsynchronousProcessor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AsynchronousProcessor.java
@@ -163,7 +163,7 @@ public abstract class AsynchronousProcessor implements CometSupport<AtmosphereRe
 
         boolean webSocketEnabled = false;
         if (req.getHeaders("Connection") != null && req.getHeaders("Connection").hasMoreElements()) {
-            String[] e = req.getHeaders("Connection").nextElement().split(",");
+            String[] e = req.getHeaders("Connection").nextElement().toString().split(",");
             for (String upgrade : e) {
                 if (upgrade.equalsIgnoreCase("Upgrade")) {
                     webSocketEnabled = true;

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceImpl.java
@@ -275,7 +275,7 @@ public class AtmosphereResourceImpl implements
         if (!event.isResumedOnTimeout()) {
 
             if (req.getHeaders("Connection") != null && req.getHeaders("Connection").hasMoreElements()) {
-                String[] e = req.getHeaders("Connection").nextElement().split(",");
+                String[] e = req.getHeaders("Connection").nextElement().toString().split(",");
                 for (String upgrade : e) {
                     if (upgrade.trim().equalsIgnoreCase(WEBSOCKET_UPGRADE)) {
                         if (writeHeaders && !cometSupport.supportWebSocket()) {


### PR DESCRIPTION
Request.getHeaders() return simple object in javax 2.5 (not Strings).

Affected resources targets to atmosphere core api, which also should work with javax 2.5.
