### PR TITLE
Fix race condition in DefaultBroadcasterFactory in Atmosphere 0.8.x

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterFactory.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterFactory.java
@@ -92,7 +92,7 @@ public abstract class BroadcasterFactory {
      *
      * @param b a {@link Broadcaster}
      * @return false if wasn't present, or {@link Broadcaster}
-     * @oaram id the {@link Broadcaster's ID}
+     * @param id the {@link Broadcaster's ID}
      */
     abstract public boolean remove(Broadcaster b, Object id);
 

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/DefaultBroadcasterFactoryTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/DefaultBroadcasterFactoryTest.java
@@ -1,0 +1,118 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.atmosphere.cpr;
+
+import org.atmosphere.cpr.AtmosphereServlet.AtmosphereConfig;
+
+import org.atmosphere.util.SimpleBroadcaster;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import static org.mockito.Mockito.*;
+
+/**
+ *
+ * @author jburgess
+ */
+public class DefaultBroadcasterFactoryTest {
+
+    private AtmosphereConfig config;
+    private DefaultBroadcasterFactory factory;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        config = mock(AtmosphereConfig.class);
+        factory = new DefaultBroadcasterFactory(DefaultBroadcaster.class, "NEVER", config);
+    }
+
+    @Test
+    public void testGet_0args() {
+        Broadcaster result = factory.get();
+        assert result != null;
+        assert result instanceof DefaultBroadcaster;
+    }
+
+    @Test
+    public void testGet_Object() {
+        String id = "id";
+        Broadcaster result = factory.get(id);
+        assert result != null;
+        assert result instanceof DefaultBroadcaster;
+        assert id.equals(result.getID());
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testGet_Object_Twice() {
+        String id = "id";
+        factory.get(id);
+        factory.get(id);
+    }
+
+    @Test
+    public void testAdd() {
+        String id = "id";
+        String id2 = "foo";
+        Broadcaster b = factory.get(id);
+        assert factory.add(b, id) == false;
+        assert factory.lookup(id) != null;
+        assert factory.add(b, id2) == true;
+        assert factory.lookup(id2) != null;
+    }
+
+    @Test
+    public void testRemove() {
+        String id = "id";
+        String id2 = "foo";
+        Broadcaster b = factory.get(id);
+        Broadcaster b2 = factory.get(id2);
+        assert factory.remove(b, id2) == false;
+        assert factory.remove(b2, id) == false;
+        assert factory.remove(b, id) == true;
+        assert factory.lookup(id) == null;
+    }
+
+    @Test
+    public void testLookup_Class_Object() {
+        String id = "id";
+        String id2 = "foo";
+        Broadcaster b = factory.get(id);
+        assert factory.lookup(DefaultBroadcaster.class, id) != null;
+        assert factory.lookup(DefaultBroadcaster.class, id2) == null;
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testLookup_Class_Object_BadClass() {
+        String id = "id";
+        factory.get(id);
+        factory.lookup(SimpleBroadcaster.class, id);
+    }
+
+    @Test
+    public void testLookup_Object() {
+        String id = "id";
+        String id2 = "foo";
+        factory.get(id);
+        assert factory.lookup(id) != null;
+        assert factory.lookup(id2) == null;
+    }
+
+    @Test
+    public void testLookup_Object_boolean() {
+        String id = "id";
+        assert factory.lookup(id, false) == null;
+        Broadcaster b = factory.lookup(id, true);
+        assert b != null;
+        assert id.equals(b.getID());
+    }
+
+    @Test
+    public void testLookup_Class_Object_boolean() {
+        String id = "id";
+        assert factory.lookup(DefaultBroadcaster.class, id, false) == null;
+        Broadcaster b = factory.lookup(DefaultBroadcaster.class, id, true);
+        assert b != null;
+        assert b instanceof DefaultBroadcaster;
+        assert id.equals(b.getID());
+    }
+}


### PR DESCRIPTION
Race condition when performing a lookup and creating if null. The synchronized statement in get(Class<? extends Broadcaster> c, Object id) is insufficient to ensure that two threads don't create a broadcaster with the same ID. Two strings that are equal, but are different objects may enter the block at the same time. To fix, make the get() method call the lookup method, and change the lookup method to better use the ConcurrentHashMap methods to guarantee that only one broadcaster can be returned with a particular ID.

Fixed remove() to use ConcurrentHashMap method to guarantee atomicity.
