### PR TITLE
GWT bug fix

### DIFF
--- a/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/AtmosphereGwtHandler.java
+++ b/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/AtmosphereGwtHandler.java
@@ -90,9 +90,9 @@ public class AtmosphereGwtHandler extends AbstractReflectorAtmosphereHandler
      * @param messages
      * @param cometResource
      */
-    public void doPost(HttpServletRequest postRequest, HttpServletResponse postResponse, 
+    public void doPost(HttpServletRequest postRequest, HttpServletResponse postResponse,
             List<Serializable> messages, GwtAtmosphereResource cometResource) {
-        if (cometResource != null && cometResource.isAlive()) {
+        if (cometResource != null) {
             if (messages.size() == 1) {
                 cometResource.post(messages.get(0));
             } else {
@@ -210,12 +210,12 @@ public class AtmosphereGwtHandler extends AbstractReflectorAtmosphereHandler
 
     /// --- server message handlers
 
-    protected void doServerMessage(HttpServletRequest request, HttpServletResponse response, int connectionID) 
+    protected void doServerMessage(HttpServletRequest request, HttpServletResponse response, int connectionID)
         throws IOException{
         BufferedReader data = request.getReader();
         List<Serializable> postMessages = new ArrayList<Serializable>();
         GwtAtmosphereResource resource = lookupResource(connectionID);
-        if (resource == null || !resource.isAlive()) {
+        if (resource == null) {
             return;
         }
         try {
@@ -287,7 +287,7 @@ public class AtmosphereGwtHandler extends AbstractReflectorAtmosphereHandler
             return null;
         }
     }
-//    
+//
 //    protected String serialize(Serializable message) throws SerializationException {
 //        ServerSerializationStreamWriter streamWriter = new ServerSerializationStreamWriter(RPCUtil.createSimpleSerializationPolicy());
 //        streamWriter.prepareToWrite();
@@ -295,7 +295,7 @@ public class AtmosphereGwtHandler extends AbstractReflectorAtmosphereHandler
 //        return streamWriter.toString();
 //	}
 
-    final public void post(HttpServletRequest postRequest, HttpServletResponse postResponse, 
+    final public void post(HttpServletRequest postRequest, HttpServletResponse postResponse,
             List<Serializable> messages, GwtAtmosphereResource cometResource) {
         if (messages == null) {
             return;
@@ -307,16 +307,14 @@ public class AtmosphereGwtHandler extends AbstractReflectorAtmosphereHandler
         if (message == null) {
             return;
         }
-        if (resource.isAlive())
-            resource.getBroadcaster().broadcast(message);
+        resource.getBroadcaster().broadcast(message);
     }
 
     public void broadcast(List<Serializable> messages, GwtAtmosphereResource resource) {
         if (messages == null) {
             return;
         }
-        if (resource.isAlive())
-            resource.getBroadcaster().broadcast(messages);
+        resource.getBroadcaster().broadcast(messages);
     }
 
     public void disconnect(GwtAtmosphereResource resource) {


### PR DESCRIPTION
Revert portions of previous patch checking if resource is alive as it was A) unnecessary and, B) caused window close events and disconnects to go unprocessed 
