### PR TITLE
Fix for Servlet 3.0 ClassCastExceptions (#368)

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/Servlet30CometSupport.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/Servlet30CometSupport.java
@@ -137,7 +137,7 @@ public class Servlet30CometSupport extends AsynchronousProcessor {
             throws IOException, ServletException {
 
         if (!req.isAsyncStarted()) {
-            AsyncContext asyncContext = req.startAsync();
+            AsyncContext asyncContext = req.startAsync(req, res);
             asyncContext.addListener(new CometListener(this));
             // Do nothing except setting the times out
             if (action.timeout() != -1) {


### PR DESCRIPTION
- startAsync() will store unwrapped request/response objects, so
  we need to call startAsync(req, res) instead
- fixes ClassCastExceptions in CometListener when timeout or error
  events are handled
