### PR TITLE
avoid duplicate InterceptorService to be added

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -477,7 +477,7 @@ public class AtmosphereFramework implements ServletContextProvider {
                     AtmosphereInterceptor ai = (AtmosphereInterceptor) Thread.currentThread().getContextClassLoader()
                             .loadClass(a.trim()).newInstance();
                     ai.configure(config);
-                    interceptors.add(ai);
+                    interceptor(ai);
                 } catch (InstantiationException e) {
                     logger.warn("", e);
                 } catch (IllegalAccessException e) {
@@ -1347,7 +1347,17 @@ public class AtmosphereFramework implements ServletContextProvider {
      * @return this
      */
     public AtmosphereFramework interceptor(AtmosphereInterceptor c) {
-        interceptors.addLast(c);
+        boolean found = false;
+        for (AtmosphereInterceptor interceptor : interceptors) {
+            if(interceptor.getClass().equals(c.getClass())){
+                found = true;
+                break;
+            }
+        }
+        
+        if(!found){
+            interceptors.addLast(c);
+        }
         return this;
     }
 


### PR DESCRIPTION
I add a validation to avoid duplicate when search for Interceptor.  Atmopshere could found AtmosphereInterceptorService at runtime and the user could have add it in web.xml.

so if AtmosphereFramework.interceptor(..) it used, it will avoid duplicate.

If you want you can still add twice and adding it with interceptors.add()  // that's the LinkedList
