### PR TITLE
Don't check status until readyState == 4 (IE bug)

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -1181,7 +1181,7 @@ jQuery.atmosphere = function() {
             }
 
             function _reconnect(ajaxRequest, request, force) {
-                if (force || (request.suspend && ajaxRequest.status == 200 && request.transport != 'streaming' && _subscribed)) {
+                if (force || (request.suspend && ajaxRequest.readyState == 4 && ajaxRequest.status == 200 && request.transport != 'streaming' && _subscribed)) {
                     _open('re-opening', request.transport, request);
                     if (request.reconnect) {
                         _executeRequest();


### PR DESCRIPTION
Before this fix, IE8 fails with "Unspecified error". See:
http://stackoverflow.com/questions/4472667/ajax-xmlhttprequest-status-unspecified-error
