### PR TITLE
Proposed fix for #442:

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterFactory.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterFactory.java
@@ -60,7 +60,7 @@ import java.util.Collection;
  */
 public abstract class BroadcasterFactory {
 
-    protected static BroadcasterFactory factory;
+    protected static BroadcasterFactory factory = new DefaultBroadcasterFactory();
     protected static AtmosphereConfig config;
 
     /**


### PR DESCRIPTION
Provided a default `BroadcasterFactory` implementation to be retrieved by `getDefault()` before any `AtmosphereResources` are referenced.
