### PR TITLE
fix for cross-domain request in IE8/9 not using XDomainRequest for push()

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -1528,6 +1528,7 @@ jQuery.atmosphere = function() {
                     requestCount : 0,
                     transport: 'polling',
                     attachHeadersAsQueryString: true,
+                    enableXDR: _request.enableXDR,
                     uuid : _request.uuid
                 };
 


### PR DESCRIPTION
as outlined in this thread: 
https://groups.google.com/d/topic/atmosphere-framework/DAmSKl_iFDg/discussion
