### PR TITLE
Change for better Atmosphere GWT / Vaadin support

### DIFF
--- a/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/GwtAtmosphereResource.java
+++ b/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/GwtAtmosphereResource.java
@@ -15,14 +15,15 @@
  */
 package org.atmosphere.gwt.server;
 
+import java.io.Serializable;
+import java.util.List;
+
+import javax.servlet.http.HttpSession;
+
 import org.atmosphere.cpr.AtmosphereRequest;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.AtmosphereResponse;
 import org.atmosphere.cpr.Broadcaster;
-
-import javax.servlet.http.HttpSession;
-import java.io.Serializable;
-import java.util.List;
 
 public interface GwtAtmosphereResource {
     public Broadcaster getBroadcaster();
@@ -50,6 +51,6 @@ public interface GwtAtmosphereResource {
     public <T> T getAttribute(String name);
 
     public int getConnectionID();
-    
+
     public boolean isSystemMessage(Serializable message);
 }

--- a/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/GwtAtmosphereResourceImpl.java
+++ b/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/GwtAtmosphereResourceImpl.java
@@ -17,6 +17,17 @@ package org.atmosphere.gwt.server.impl;
 
 import com.google.gwt.rpc.server.ClientOracle;
 import com.google.gwt.user.server.rpc.SerializationPolicy;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.http.HttpSession;
+
 import org.atmosphere.cpr.AtmosphereRequest;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.AtmosphereResourceEvent;
@@ -30,15 +41,6 @@ import org.atmosphere.gwt.server.GwtResponseWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpSession;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
 /**
  * @author p.havelaar
  */
@@ -48,10 +50,16 @@ public class GwtAtmosphereResourceImpl implements GwtAtmosphereResource {
 
     public GwtAtmosphereResourceImpl(AtmosphereResource resource,
                                      AtmosphereGwtHandler servlet, int heartBeatInterval) throws IOException {
+        this(resource, servlet, heartBeatInterval, true);
+    }
+
+    public GwtAtmosphereResourceImpl(AtmosphereResource resource, AtmosphereGwtHandler servlet,
+                                     int heartBeatInterval, boolean escapeText) throws IOException {
         this.atmosphereHandler = servlet;
         this.atmResource = resource;
         this.heartBeatInterval = heartBeatInterval;
         this.writer = createResponseWriter();
+        this.writer.escapeText(escapeText);
         resource.getRequest().setAttribute(GwtAtmosphereResource.class.getName(), this);
     }
 
@@ -129,7 +137,7 @@ public class GwtAtmosphereResourceImpl implements GwtAtmosphereResource {
     @Override
     public boolean isSystemMessage(Serializable message) {
         return HEARTBEAT_MESSAGE.equals(message);
-    }    
+    }
 
     long getStartTime() {
         return startTime;

--- a/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/IFrameResponseWriter.java
+++ b/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/IFrameResponseWriter.java
@@ -151,11 +151,14 @@ public class IFrameResponseWriter extends ManagedStreamResponseWriter {
         }
     }
 
-    private static CharSequence escapeString(CharSequence string) {
-        int length = (string != null) ? string.length() : 0;
+    private CharSequence escapeString(CharSequence string) {
+        if (!this.shouldEscapeText())
+            return string;
+
+        int len = (string != null) ? string.length() : 0;
         int i = 0;
         loop:
-        while (i < length) {
+        while (i < len) {
             char ch = string.charAt(i);
             switch (ch) {
                 case '\'':
@@ -170,12 +173,12 @@ public class IFrameResponseWriter extends ManagedStreamResponseWriter {
             i++;
         }
 
-        if (i == length)
+        if (i == len)
             return string;
 
         StringBuilder str = new StringBuilder(string.length() * 2);
         str.append(string, 0, i);
-        while (i < length) {
+        while (i < len) {
             char ch = string.charAt(i);
             switch (ch) {
                 case '\'':
@@ -210,11 +213,14 @@ public class IFrameResponseWriter extends ManagedStreamResponseWriter {
         return str;
     }
 
-    private static CharSequence escapeObject(CharSequence string) {
-        int length = (string != null) ? string.length() : 0;
+    private CharSequence escapeObject(CharSequence string) {
+        if (!this.shouldEscapeText())
+            return string;
+
+        int len = (string != null) ? string.length() : 0;
         int i = 0;
         loop:
-        while (i < length) {
+        while (i < len) {
             char ch = string.charAt(i);
             switch (ch) {
                 case '\'':
@@ -225,12 +231,12 @@ public class IFrameResponseWriter extends ManagedStreamResponseWriter {
             i++;
         }
 
-        if (i == length)
+        if (i == len)
             return string;
 
         StringBuilder str = new StringBuilder(string.length() * 2);
         str.append(string, 0, i);
-        while (i < length) {
+        while (i < len) {
             char ch = string.charAt(i);
             switch (ch) {
                 case '\'':

--- a/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/OperaEventSourceResponseWriter.java
+++ b/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/OperaEventSourceResponseWriter.java
@@ -63,7 +63,9 @@ public class OperaEventSourceResponseWriter extends GwtResponseWriterImpl {
             CharSequence string;
             char event;
             if (message instanceof CharSequence) {
-                string = HTTPRequestResponseWriter.escape((CharSequence) message);
+                string = (CharSequence) message;
+                if (this.shouldEscapeText())
+                    string = HTTPRequestResponseWriter.escape(string);
                 event = 's';
             } else {
                 string = serialize(message);

--- a/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/RPCUtil.java
+++ b/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/RPCUtil.java
@@ -20,10 +20,7 @@ import com.google.gwt.rpc.server.ClientOracle;
 import com.google.gwt.rpc.server.HostedModeClientOracle;
 import com.google.gwt.rpc.server.WebModeClientOracle;
 import com.google.gwt.user.server.rpc.SerializationPolicy;
-import org.atmosphere.gwt.shared.Constants;
 
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.SoftReference;
@@ -31,6 +28,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+
+import org.atmosphere.gwt.shared.Constants;
 
 /**
  * @author p.havelaar

--- a/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/StreamingProtocolResponseWriter.java
+++ b/extras/gwt/atmosphere-gwt-server/src/main/java/org/atmosphere/gwt/server/impl/StreamingProtocolResponseWriter.java
@@ -135,7 +135,9 @@ abstract public class StreamingProtocolResponseWriter extends ManagedStreamRespo
         for (Serializable message : messages) {
             CharSequence string;
             if (message instanceof CharSequence) {
-                string = escape((CharSequence) message);
+                string = (CharSequence) message;
+                if (this.shouldEscapeText())
+                    string = escape(string);
                 if (string == message) {
                     writer.append('|');
                 } else {


### PR DESCRIPTION
Add mechanism to tell the GWT response writer implementations not to escape the messages they write.

This is necessary for those using Atmosphere with Vaadin via the DontPush-OzoneLayer add-on as Vaadin already escapes the JSON text thus the extra escaping done by the GWT response writers causes issues (especially with newline characters).
