### PR TITLE
Pull request for issue #502

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/MeteorServlet.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/MeteorServlet.java
@@ -95,22 +95,21 @@ public class MeteorServlet extends AtmosphereServlet {
 
         if (servletClass != null) {
             logger.info("Installed Servlet/Meteor {} mapped to {}", servletClass, mapping == null ? "/*" : mapping);
-
-            if (filterClass != null) {
-                logger.info("Installed Filter/Meteor {} mapped to /*", filterClass, mapping);
-            }
-
-            ReflectorServletProcessor r = new ReflectorServletProcessor();
-            r.setServletClassName(servletClass);
-            r.setFilterClassName(filterClass);
-            r.setFilterName(filterName);
-
-            if (mapping == null) {
-                mapping = "/*";
-                BroadcasterFactory.getDefault().remove("/*");
-            }
-            framework.addAtmosphereHandler(mapping, r).initAtmosphereHandler(sc);
         }
+        if (filterClass != null) {
+            logger.info("Installed Filter/Meteor {} mapped to /*", filterClass, mapping);
+        }
+
+        ReflectorServletProcessor r = new ReflectorServletProcessor();
+        r.setServletClassName(servletClass);
+        r.setFilterClassName(filterClass);
+        r.setFilterName(filterName);
+
+        if (mapping == null) {
+            mapping = "/*";
+            BroadcasterFactory.getDefault().remove("/*");
+        }
+        framework.addAtmosphereHandler(mapping, r).initAtmosphereHandler(sc);
     }
 
     @Override


### PR DESCRIPTION
Fix Meteor Servlet so that org.atmosphere.servlet init param  is not required for org.atmosphere.filter init param to be processed.
