### PR TITLE
fix for BroadcasterCacheBase IllegalStateException

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cache/BroadcasterCacheBase.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cache/BroadcasterCacheBase.java
@@ -175,7 +175,7 @@ public abstract class BroadcasterCacheBase implements BroadcasterCache {
 
         CachedMessage cm = retrieveLastMessage(r);
         boolean isNew = false;
-        if (cm == null && r.getRequest().getAttribute(AtmosphereResourceImpl.PRE_SUSPEND) != null) {
+        if (cm == null && AtmosphereResourceImpl.class.cast(r).isInScope() && r.getRequest().getAttribute(AtmosphereResourceImpl.PRE_SUSPEND) != null) {
             isNew = true;
         }
 


### PR DESCRIPTION
I use a custom BroadcasterCache that extends BroadcasterCacheBase, and I had an issue with atmosphere throwing:
java.lang.IllegalStateException: Request object no longer valid. This object has been cancelled.

The cause is a call to AtmosphereResourceImpl#getRequest(), which fails scope check.
