### PR TITLE
Propagate flushComments correctly

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceImpl.java
@@ -359,7 +359,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
             timeoutms = TimeUnit.MILLISECONDS.convert(timeout, timeunit);
         }
 
-        return suspend(timeoutms, true);
+        return suspend(timeoutms, flushComment);
     }
 
     public AtmosphereResource suspend(long timeout, boolean flushComment) {


### PR DESCRIPTION
suspend(long, TimeUnit, boolean) was not properly propagating flushComments to suspend(long, boolean).
