### PR TITLE
SSE origin check becomes protocol agnostic

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -913,8 +913,8 @@ jQuery.atmosphere = function() {
                 };
 
                 _sse.onmessage = function(message) {
-                    if (message.origin != "http://" + window.location.host) {
-                        jQuery.atmosphere.log(_request.logLevel, ["Origin was not " + "http://" + window.location.host]);
+                    if (message.origin != window.location.protocol + "//" + window.location.host) {
+                        jQuery.atmosphere.log(_request.logLevel, ["Origin was not " + window.location.protocol + "//" + window.location.host]);
                         return;
                     }
 


### PR DESCRIPTION
Currently using SSE transport protocol with HTTPS will fail, with a message printed to the console about the request not being of the same origin. The reason is that  in the origin check, http is hardcoded. I have changed the code to determine the protocol via the location object. SSE will now work with HTTP and HTTPS.
