### PR TITLE
Possible NumberFormatException when HttpSession#getAttribute returns null.

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cache/SessionBroadcasterCache.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cache/SessionBroadcasterCache.java
@@ -100,8 +100,10 @@ public class SessionBroadcasterCache extends AbstractBroadcasterCache {
             logger.error(ERROR_MESSAGE);
             return result;
         }
-
-        Long cacheHeaderTime = Long.valueOf((String) session.getAttribute(broadcasterId));
+        
+        String cacheHeaderTimeStr = (String)session.getAttribute(broadcasterId);
+        if (cacheHeaderTimeStr == null) return result;
+        Long cacheHeaderTime = Long.valueOf(cacheHeaderTimeStr);
         if (cacheHeaderTime == null) return result;
 
         return get(cacheHeaderTime);


### PR DESCRIPTION
When using SessionBroadcasterCache I get an exception when calling Broadcaster#addResource.  The exception is generated when calling:

``` java
Long.valueof((String)session.getAttribute(broadcasterId));
```

For me the HttpSession#getAttribute call returns null so I added a null check.

I am not sure if this is all that it needed but the build compiles without error and as far as I can tell the problem is fixed for me.
