### PR TITLE
fixed bug where requests-array was modified while iterating

### DIFF
--- a/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
+++ b/modules/jquery/src/main/webapp/jquery/jquery.atmosphere.js
@@ -2288,9 +2288,11 @@ jQuery.atmosphere = function() {
 
         unsubscribe : function() {
             if (jQuery.atmosphere.requests.length > 0) {
-                for (var i = 0; i < jQuery.atmosphere.requests.length; i++) {
-                    jQuery.atmosphere.requests[i].close();
-                    clearTimeout(jQuery.atmosphere.requests[i].id);
+              var requestsClone = [].concat(jQuery.atmosphere.requests);
+              for (var i = 0; i < requestsClone.length; i++) {
+                    var rq = requestsClone[i];
+                    rq.close();
+                    clearTimeout(rq.id);
                 }
             }
             jQuery.atmosphere.requests = [];


### PR DESCRIPTION
a call to request.close() could lead to unregistering the request by
external libraries so that the second call (to clear the timeout) cannot
access the request via its index anymore. 
Fix is to get hold of the request and operate on the instance.

Could this fix be backported to previous versions of atmosphere, too?

Thanks for this library! :)
