### PR TITLE
Patch to enable passing instances of Servlets and Filters to MeteorServlet.

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/MeteorServlet.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/MeteorServlet.java
@@ -56,13 +56,15 @@ import org.atmosphere.handler.ReflectorServletProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.servlet.Filter;
+import javax.servlet.Servlet;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 
-import static org.atmosphere.cpr.ApplicationConfig.FILTER_CLASS;
-import static org.atmosphere.cpr.ApplicationConfig.FILTER_NAME;
-import static org.atmosphere.cpr.ApplicationConfig.MAPPING;
-import static org.atmosphere.cpr.ApplicationConfig.SERVLET_CLASS;
+import static org.atmosphere.cpr.ApplicationConfig.*;
 
 /**
  * Simple Servlet to use when Atmosphere {@link Meteor} are used. This Servlet will look
@@ -76,6 +78,12 @@ import static org.atmosphere.cpr.ApplicationConfig.SERVLET_CLASS;
 public class MeteorServlet extends AtmosphereServlet {
     protected static final Logger logger = LoggerFactory.getLogger(MeteorServlet.class);
 
+    private Servlet delegate;
+
+    private String delegateMapping;
+
+    private Collection<Filter> filters;
+
     public MeteorServlet() {
         this(false);
     }
@@ -84,10 +92,41 @@ public class MeteorServlet extends AtmosphereServlet {
         super(isFilter, false);
     }
 
+    public MeteorServlet(Servlet delegate, String delegateMapping, Filter... filters) {
+        this(delegate, delegateMapping, Arrays.asList(filters));
+    }
+
+    public MeteorServlet(Servlet delegate, String delegateMapping, Collection<Filter> filters) {
+        this(false);
+        if (delegate == null || delegateMapping == null) {
+            throw new IllegalArgumentException("Delegate Servlet is undefined");
+        }
+        this.delegate = delegate;
+        this.delegateMapping = delegateMapping;
+        if (filters == null) {
+            this.filters = Collections.emptyList();
+        } else {
+            this.filters = filters;
+        }
+    }
+
     @Override
     public void init(final ServletConfig sc) throws ServletException {
         super.init(sc);
 
+        if (delegate == null) {
+            loadDelegateViaConfig(sc);
+        } else {
+            ReflectorServletProcessor r = new ReflectorServletProcessor(delegate);
+            for (Filter f : filters) {
+                r.addFilter(f);
+            }
+            BroadcasterFactory.getDefault().remove(delegateMapping);
+            framework.addAtmosphereHandler(delegateMapping, r).initAtmosphereHandler(sc);
+        }
+    }
+
+    private void loadDelegateViaConfig(ServletConfig sc) throws ServletException {
         String servletClass = framework().getAtmosphereConfig().getInitParameter(SERVLET_CLASS);
         String mapping = framework().getAtmosphereConfig().getInitParameter(MAPPING);
         String filterClass = framework().getAtmosphereConfig().getInitParameter(FILTER_CLASS);
@@ -104,9 +143,7 @@ public class MeteorServlet extends AtmosphereServlet {
         if (servletClass != null || filterClass != null) {
             ReflectorServletProcessor r = new ReflectorServletProcessor();
             r.setServletClassName(servletClass);
-            r.setFilterClassName(filterClass);
-            r.setFilterName(filterName);
-
+            r.addFilterClassName(filterClass, filterName);
             if (mapping == null) {
                 mapping = "/*";
                 BroadcasterFactory.getDefault().remove("/*");


### PR DESCRIPTION
Patch to enable passing instances of Servlets and Filters to MeteorServlet. Useful when using Servlet 3.0 style for defining web applications.

See this thread:

https://groups.google.com/forum/?fromgroups=#!topic/atmosphere-framework/fxVDv4d-YZc
