### PR TITLE
added the functionality of sending message timestamp along with message

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cache/HeaderBroadcasterCachePlus.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cache/HeaderBroadcasterCachePlus.java
@@ -1,0 +1,90 @@
+package org.atmosphere.cache;
+
+import static org.atmosphere.cpr.HeaderConfig.X_CACHE_DATE;
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.atmosphere.cpr.AtmosphereResource;
+
+
+public class HeaderBroadcasterCachePlus extends HeaderBroadcasterCache { 
+	
+	//assuming that only one instance of HeaderBroadcasterCachePlus exists. Otherwise the following static fields can't serve their purpose. 
+	public static Hashtable<String, Long> messageCachedTimes = new Hashtable<String, Long>(); 
+	public static Hashtable<String, Boolean> messageCachedTimesFlag = new Hashtable<String, Boolean>();
+	public static final ReadWriteLock readWriteLockForMessageCachedTimes = new ReentrantReadWriteLock();
+	
+	
+	@Override
+	public void start() {
+		scheduledFuture = reaper.scheduleAtFixedRate(new Runnable() {
+
+            public void run() {
+                readWriteLock.writeLock().lock();
+                try {
+                    long now = System.nanoTime();
+                    List<CacheMessage> expiredMessages = new ArrayList<CacheMessage>();
+
+                    for (CacheMessage message : messages) {
+                        if (TimeUnit.NANOSECONDS.toMillis(now - message.getCreateTime()) > maxCacheTime) {
+                            expiredMessages.add(message);
+                        }
+                    }
+
+                    for (CacheMessage expiredMessage : expiredMessages) {
+                        messages.remove(expiredMessage);
+                        messagesIds.remove(expiredMessage.getId());
+                        
+                        readWriteLockForMessageCachedTimes.writeLock().lock();
+                        try {
+                        	Boolean flag = messageCachedTimesFlag.get(expiredMessage.getMessage().toString());
+                        	if(flag!=null && !flag) {
+                        		messageCachedTimesFlag.remove(expiredMessage.getMessage().toString());
+                        		messageCachedTimes.remove(expiredMessage.getMessage().toString());
+                        	}
+                        } finally {
+                        	readWriteLockForMessageCachedTimes.writeLock().unlock();
+                        }
+                        
+                    }
+                } finally {
+                    readWriteLock.writeLock().unlock();
+                }
+            }
+        }, 0, invalidateCacheInterval, TimeUnit.MILLISECONDS);
+	}
+	
+	@Override
+	public void addToCache(String broadcasterId, AtmosphereResource r, Message e) {
+        long now = System.nanoTime();
+        
+        
+        readWriteLockForMessageCachedTimes.writeLock().lock();
+        try {
+            if(messageCachedTimes.get(e.message.toString())==null) {
+            	messageCachedTimes.put(e.message.toString(), now);
+            } else {
+            	//let timestamp be of old message that is same as current message. In this case there might be duplicate deliveries.
+            }
+            messageCachedTimesFlag.put(e.message.toString(), true);
+        } finally {
+        	readWriteLockForMessageCachedTimes.writeLock().unlock();
+        }
+
+        
+        
+        put(e, now);
+        if (r != null) {
+            r.getResponse().setHeader(X_CACHE_DATE, String.valueOf(now));
+        }
+	}	
+	public CacheMessage getCacheMessage(String id) {
+		return null;
+	}
+
+}

--- a/modules/cpr/src/main/java/org/atmosphere/client/HeaderBroadcasterPlusInterceptor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/client/HeaderBroadcasterPlusInterceptor.java
@@ -1,0 +1,95 @@
+package org.atmosphere.client;
+
+import static org.atmosphere.cpr.ApplicationConfig.PROPERTY_USE_STREAM;
+
+import java.io.UnsupportedEncodingException;
+
+import org.atmosphere.cache.HeaderBroadcasterCachePlus;
+import org.atmosphere.cpr.Action;
+import org.atmosphere.cpr.ApplicationConfig;
+import org.atmosphere.cpr.AsyncIOInterceptorAdapter;
+import org.atmosphere.cpr.AsyncIOWriter;
+import org.atmosphere.cpr.AtmosphereConfig;
+import org.atmosphere.cpr.AtmosphereInterceptorAdapter;
+import org.atmosphere.cpr.AtmosphereInterceptorWriter;
+import org.atmosphere.cpr.AtmosphereResource;
+import org.atmosphere.cpr.AtmosphereResourceEventImpl;
+import org.atmosphere.cpr.AtmosphereResourceImpl;
+import org.atmosphere.cpr.AtmosphereResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HeaderBroadcasterPlusInterceptor extends AtmosphereInterceptorAdapter {
+
+    private static final Logger logger = LoggerFactory.getLogger(HeaderBroadcasterPlusInterceptor.class);
+
+    private final static byte[] END = "##".getBytes();
+    private byte[] end = END;
+    private String endString = "##";
+
+    @Override
+    public void configure(AtmosphereConfig config) {
+        String s = config.getInitParameter(ApplicationConfig.MESSAGE_TIMESTAMP_DELIMITER);
+        if (s != null) {
+            end = s.getBytes();
+            endString = s;
+        }
+    }
+
+    @Override
+    public Action inspect(final AtmosphereResource r) {
+        final AtmosphereResponse response = r.getResponse();
+
+        super.inspect(r);
+
+        AsyncIOWriter writer = response.getAsyncIOWriter();
+        if (AtmosphereInterceptorWriter.class.isAssignableFrom(writer.getClass())) {
+            AtmosphereInterceptorWriter.class.cast(writer).interceptor(new AsyncIOInterceptorAdapter() {
+
+                @Override
+                public void postPayload(AtmosphereResponse response, byte[] data, int offset, int length) {
+                	String message = new String(data);
+                	boolean isUsingStream = (Boolean) response.request().getAttribute(PROPERTY_USE_STREAM);
+                	if(isUsingStream) {
+                		try {
+							message = new String(data, response.getCharacterEncoding());
+						} catch (UnsupportedEncodingException e) {
+					        AtmosphereResource r = response.resource();
+					        if (r != null) {
+					            AtmosphereResourceImpl.class.cast(r).notifyListeners(
+					                    new AtmosphereResourceEventImpl(AtmosphereResourceImpl.class.cast(r), true, false));
+					        }
+					        logger.trace("", e);
+					        return;
+						}
+                	}
+                	
+                	HeaderBroadcasterCachePlus.readWriteLockForMessageCachedTimes.writeLock().lock();
+                    try {
+                    	String timestamp = Long.toString(HeaderBroadcasterCachePlus.messageCachedTimes.get(message));
+                    	timestamp = new String(end) + timestamp;
+                        response.write(timestamp.getBytes());
+                        
+                        Boolean flag = HeaderBroadcasterCachePlus.messageCachedTimesFlag.get(message);
+                        if(flag!=null && flag) {
+                        	HeaderBroadcasterCachePlus.messageCachedTimesFlag.put(message.toString(), false);
+                        }
+                    } finally {
+                    	HeaderBroadcasterCachePlus.readWriteLockForMessageCachedTimes.writeLock().unlock();
+                    }
+
+                    
+                }
+
+            });
+        } else {
+            logger.warn("Unable to apply {}. Your AsyncIOWriter must implement {}", getClass().getName(), AtmosphereInterceptorWriter.class.getName());
+        }
+        return Action.CONTINUE;
+    }
+
+    @Override
+    public String toString() {
+        return endString + " Header Broadcaster Plus Interceptor";
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
@@ -15,6 +15,7 @@
  */
 package org.atmosphere.cpr;
 
+import org.atmosphere.client.HeaderBroadcasterPlusInterceptor;
 import org.atmosphere.client.MessageLengthInterceptor;
 import org.atmosphere.client.TrackMessageSizeInterceptor;
 import org.atmosphere.interceptor.AtmosphereResourceLifecycleInterceptor;
@@ -279,6 +280,11 @@ public interface ApplicationConfig {
      * received in one chunk. Default is '<||>'
      */
     String MESSAGE_DELIMITER = TrackMessageSizeInterceptor.class.getName() + ".delimiter";
+    /**
+     * The token used to separate message generated time and message. This value is used by the client to parse the message received
+     * to get the time on server when the message got generated. Default is '<##>'
+     */
+    String MESSAGE_TIMESTAMP_DELIMITER = HeaderBroadcasterPlusInterceptor.class.getName() + ".delimiter";
     /**
      * The method used that trigger automatic management of {@link AtmosphereResource} when the {@link AtmosphereResourceLifecycleInterceptor}
      * is used


### PR DESCRIPTION
By sending the timestamp of each message appended to message, client will be able to parse the received message with timestamp and set X-Cache-Date header to get the cached messages from the point exactly where client needs.

If server tries to push same message more than once within cache timeout, the timestamp of the older message will be appended to message and duplicate deliveries can occur. I could not think of a way to uniquely identify the message in context of atmosphere. The message object gets cached at BroadcasterCache class and the Interceptor appends the timestamp. The message object that got cached is tranformed to some other object by the time it reaches interceptor.

This code will not work in case where the broadcast cache strategy is beforeFilter and the broadcaster filter changes the message object.

Related post on Atmosphere Framework mailing list - https://groups.google.com/forum/?fromgroups=#!topic/atmosphere-framework/A4my3qdoacc
