### PR TITLE
Broadcaster instantiated before annotations processed

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -556,8 +556,8 @@ public class AtmosphereFramework implements ServletContextProvider {
             configureScanningPackage(scFacade);
             installAnnotationProcessor(scFacade);
 
-            configureBroadcasterFactory();
             autoConfigureService(scFacade.getServletContext());
+            configureBroadcasterFactory();
             patchContainer();
             configureBroadcaster();
             loadConfiguration(scFacade);


### PR DESCRIPTION
In `AtmosphereFramework.java`, `configureBroadcasterFactory()`, which instantiates the broadcaster, is called before `autoConfigureService()`, which scans for annotations, including `@BroadcasterService`.
