### PR TITLE
Allow disabling the Commercial Support message

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
@@ -543,5 +543,11 @@ public interface ApplicationConfig {
      * Value: "org.atmosphere.cpr.Broadcaster.POLICY.maximumSuspended"
      */
     String BROADCASTER_POLICY_TIMEOUT = Broadcaster.POLICY.class.getName() + ".maximumSuspended";
+    /**
+     * Allows suppressing the message about commercial support during startup.
+     * Default is true
+     * Value: org.atmosphere.cpr.showSupportMessage
+     */
+    String SHOW_SUPPORT_MESSAGE = ApplicationConfig.class.getPackage().getName() + ".showSupportMessage";
 }
 

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -562,8 +562,12 @@ public class AtmosphereFramework implements ServletContextProvider {
             logger.info("Using WebSocketProcessor: {}", webSocketProcessorClassName);
             logger.info("Using Broadcaster: {}", broadcasterClassName);
             logger.info("Atmosphere Framework {} started.", Version.getRawVersion());
-            logger.info("\n\n\tFor Commercial Support, visit \n\t{} " +
-                    "or send an email to {}\n", "http://www.async-io.org/", "support@async-io.org");
+
+            String showSupportMessage = config.getInitParameter(ApplicationConfig.SHOW_SUPPORT_MESSAGE);
+            if (showSupportMessage == null || Boolean.parseBoolean(showSupportMessage)) {
+                logger.info("\n\n\tFor Commercial Support, visit \n\t{} " +
+                        "or send an email to {}\n", "http://www.async-io.org/", "support@async-io.org");
+            }
         } catch (Throwable t) {
             logger.error("Failed to initialize Atmosphere Framework", t);
 


### PR DESCRIPTION
When including Atmosphere as an implementation detail in a product that
provides its own commercial support, the message printed during Atmosphere
initialization might make the user believe that async-io.org provides
commercial support for the entire product, which is obviously not the case.

This change lets integrators disable the message to avoid confusion.
