### PR TITLE
change atmosphere-integration module name to same value as artefact name

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>atmosphere-integration</artifactId>
     <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>atmosphere-modules</name>
+    <name>atmosphere-integration</name>
     <url>https://github.com/Atmosphere/atmosphere</url>
 
     <modules>


### PR DESCRIPTION
only a cosmetic change, but this would improve the presentation in my IDE
