### PR TITLE
Clean up class loading problem with the ServletContainerInitializer

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AnnotationScanningServletContainerInitializer.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AnnotationScanningServletContainerInitializer.java
@@ -55,11 +55,6 @@ import org.atmosphere.config.service.WebSocketProtocolService;
 })
 public class AnnotationScanningServletContainerInitializer implements ServletContainerInitializer {
 
-    /**
-     * The attribute name under which the annotations are stored in the servlet context
-     */
-    public static final String ANNOTATION_ATTRIBUTE = AnnotationScanningServletContainerInitializer.class.getPackage().getName() + ".ANNOTATION_MAP";
-
     @Override
     public void onStartup(final Set<Class<?>> classes, final ServletContext servletContext) throws ServletException {
         final Map<Class<? extends Annotation>, Set<Class<?>>> classesByAnnotation = new HashMap<Class<? extends Annotation>, Set<Class<?>>>();
@@ -72,6 +67,6 @@ public class AnnotationScanningServletContainerInitializer implements ServletCon
                 classSet.add(clazz);
             }
         }
-        servletContext.setAttribute(ANNOTATION_ATTRIBUTE, Collections.unmodifiableMap(classesByAnnotation));
+        servletContext.setAttribute(DefaultAnnotationProcessor.ANNOTATION_ATTRIBUTE, Collections.unmodifiableMap(classesByAnnotation));
     }
 }

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAnnotationProcessor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAnnotationProcessor.java
@@ -53,22 +53,19 @@ public class DefaultAnnotationProcessor implements AnnotationProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultAnnotationProcessor.class);
 
+
+    /**
+     * The attribute name under which the annotations are stored in the servlet context
+     */
+    public static final String ANNOTATION_ATTRIBUTE = "org.atmosphere.cpr.ANNOTATION_MAP";
+
     private AnnotationProcessor delegate;
 
     @Override
     public AnnotationProcessor configure(final AtmosphereFramework framework) {
         ServletContext sc = framework.getServletContext();
 
-        Map<Class<? extends Annotation>, Set<Class<?>>> annotations = null;
-        // Servlet 3.0 only.
-        if (sc.getMajorVersion() > 2) {
-            // Since we deploy in non servlet framework, we must make sure we catch any exception in order to avoid regression.
-            try {
-                annotations = (Map<Class<? extends Annotation>, Set<Class<?>>>) sc.getAttribute(AnnotationScanningServletContainerInitializer.ANNOTATION_ATTRIBUTE);
-            } catch (Exception ex) {
-                logger.trace("", ex);
-            }
-        }
+        Map<Class<? extends Annotation>, Set<Class<?>>> annotations = (Map<Class<? extends Annotation>, Set<Class<?>>>) sc.getAttribute(ANNOTATION_ATTRIBUTE);
 
         if (annotations == null) {
             delegate = new BytecodeBasedAnnotationProcessor();


### PR DESCRIPTION
Sorry about the problem with my last PR. Basically the problem was just because the ANNOTATION_ATTRIBUTE contstant was on the SCI class. Even then this would not have been a problem if I had just hard coded the attribute name instead of using .getPackage() to generate the attribute name,

Rather than trying to catch the solution I think it is cleaner to just move the attribute name. 
