### PR TITLE
Detects the RMIBroadcaster in classpath when Atmosphere starts

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -115,6 +115,7 @@ import static org.atmosphere.cpr.FrameworkConfig.HAZELCAST_BROADCASTER;
 import static org.atmosphere.cpr.FrameworkConfig.JERSEY_BROADCASTER;
 import static org.atmosphere.cpr.FrameworkConfig.JERSEY_CONTAINER;
 import static org.atmosphere.cpr.FrameworkConfig.JGROUPS_BROADCASTER;
+import static org.atmosphere.cpr.FrameworkConfig.RMI_BROADCASTER;
 import static org.atmosphere.cpr.FrameworkConfig.JMS_BROADCASTER;
 import static org.atmosphere.cpr.FrameworkConfig.REDIS_BROADCASTER;
 import static org.atmosphere.cpr.FrameworkConfig.WRITE_HEADERS;
@@ -261,6 +262,7 @@ public class AtmosphereFramework implements ServletContextProvider {
         broadcasterTypes.add(REDIS_BROADCASTER);
         broadcasterTypes.add(JGROUPS_BROADCASTER);
         broadcasterTypes.add(JMS_BROADCASTER);
+        broadcasterTypes.add(RMI_BROADCASTER);
     }
 
     /**
@@ -1067,6 +1069,7 @@ public class AtmosphereFramework implements ServletContextProvider {
             } catch (ClassNotFoundException e) {
             }
         }
+
         return defaultB;
     }
 

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/FrameworkConfig.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/FrameworkConfig.java
@@ -44,6 +44,10 @@ public interface FrameworkConfig {
      */
     String JGROUPS_BROADCASTER = "org.atmosphere.plugin.jgroups.JGroupsBroadcaster";
     /**
+     * The default RMI Broadcaster class
+     */
+    String RMI_BROADCASTER = "org.atmosphere.plugin.rmi.RMIBroadcaster";
+    /**
      * The default XMPP Broadcaster class
      */
     String XMPP_BROADCASTER = "org.atmosphere.plugin.xmpp.XMPPBroadcaster";


### PR DESCRIPTION
The RMIBroadcaster already [pulled](https://github.com/Atmosphere/atmosphere-extensions/pull/91) needs to be detected when atmosphere starts.
