### PR TITLE
HeartbeatInterceptor: Force use of AsyncIOWriter.

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/interceptor/HeartbeatInterceptor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/interceptor/HeartbeatInterceptor.java
@@ -102,7 +102,7 @@ public class HeartbeatInterceptor extends AtmosphereInterceptorAdapter {
                                 logger.trace("Writing heartbeat for {}", r.uuid());
                                 if (r.isSuspended()) {
                                     try {
-                                        response.write(paddingText, true);
+                                        response.write(paddingText, false);
                                     } catch (Throwable t) {
                                         logger.trace("{}", r.uuid(), t);
                                         writeFuture.cancel(false);


### PR DESCRIPTION
Without forcing AsyncIOWriter to be used only the first heartbeat is sent when using SSE.
