### PR TITLE
don't return invalid session from AtmosphereRequest#getSession

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/util/FakeHttpSession.java
+++ b/modules/cpr/src/main/java/org/atmosphere/util/FakeHttpSession.java
@@ -28,6 +28,7 @@ public class FakeHttpSession implements HttpSession {
     private final String sessionId;
     private final ServletContext servletContext;
     private int maxInactiveInterval;
+    private boolean valid = true;
 
     public FakeHttpSession(String sessionId, ServletContext servletContext, long creationTime, int maxInactiveInterval) {
         this.sessionId = sessionId;
@@ -136,13 +137,14 @@ public class FakeHttpSession implements HttpSession {
         return this;
     }
 
-    // TODO: Not supported for now.
     @Override
     public void invalidate() {
+    	valid = false;
     }
 
     @Override
     public boolean isNew() {
+    	if (!valid) throw new IllegalStateException();
         return false;
     }
 

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/SessionTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/SessionTest.java
@@ -16,11 +16,13 @@
 package org.atmosphere.cpr;
 
 import org.atmosphere.container.BlockingIOCometSupport;
+import org.atmosphere.cpr.AtmosphereRequest.NoOpsRequest;
 import org.atmosphere.util.FakeHttpSession;
 import org.testng.annotations.Test;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
@@ -67,6 +69,24 @@ public class SessionTest {
                 mock(AsyncSupport.class));
 
         assertNotNull(r.session());
+        assertNotNull(r.session(true));
+    }
+    
+    @Test
+    public void sessionReplacementTest() {
+    	AtmosphereConfig config = new AtmosphereFramework().getAtmosphereConfig();
+    	config.setSupportSession(true);
+    	
+    	HttpServletRequest httpRequest = new NoOpsRequest();
+        AtmosphereRequest request = new AtmosphereRequest.Builder().request(httpRequest).session(httpRequest.getSession(true)).build();
+        AtmosphereResponse response = new AtmosphereResponse.Builder().build();
+        AtmosphereResource r = AtmosphereResourceFactory.getDefault().create(config, request, response, mock(AsyncSupport.class));
+        
+        request.setAttribute(FrameworkConfig.ATMOSPHERE_RESOURCE, r);
+
+        assertNotNull(request.getSession());
+        request.getSession().invalidate();
+        assertNull(request.getSession(false));
         assertNotNull(r.session(true));
     }
 }


### PR DESCRIPTION
Issue #1074 reported a problem with session replacement within a single request. Session replacement is a common pattern to discourage session fixation attacks. A fix was committed introducing SessionSupport which clears the HTTP session from registered resources when the session is destroyed. However, this does not clear the session from the resource in the AtmosphereRequest's attribute map. So calls to HttpServletRequest#getSession() still return this invalid session.

This pull request includes a unit test demonstrating the issue. It's also apparent from this simple Filter. When served through Atmosphere, the second request results in an IllegalStateException.

``` java
    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException {
        HttpServletRequest httpRequest = (HttpServletRequest) request;

        if (httpRequest.getSession(true).isNew()) {
            response.getOutputStream().write("session created".getBytes());
        }
        else {
            try {
                httpRequest.getSession().invalidate();
                httpRequest.getSession(true).getAttribute("test");
            }
            catch (RuntimeException e) {
                e.printStackTrace();
                throw e;
            }
        }
    }
```

I am new to Atmosphere so maybe there is a more direct way to access and reset this resource's session. This pull request simply introduces a validity check in AtmosphereRequest#getSession().
