### PR TITLE
Allow disabling the analytics call during initialization.

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
@@ -573,6 +573,13 @@ public interface ApplicationConfig {
      */
     String SHOW_SUPPORT_MESSAGE = ApplicationConfig.class.getPackage().getName() + ".showSupportMessage";
     /**
+     * Allows disabling calling home to determine if there is a newer version of Atmosphere available.
+     * <p>
+     * Default: true<br>
+     * Value: org.atmosphere.cpr.checkVersion
+     */
+    String CHECK_VERSION = ApplicationConfig.class.getPackage().getName() + ".checkVersion";
+    /**
      * The timeout, in milliseconds, before an {@link AtmosphereResource}'s state get discarded.
      * <p>
      * Default: 300000 (5 minutes)<br>

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -583,7 +583,10 @@ public class AtmosphereFramework implements ServletContextProvider {
             asyncSupport.init(scFacade);
             initAtmosphereHandler(scFacade);
             configureAtmosphereInterceptor(sc);
-            analytics();
+            String checkVersion = config.getInitParameter(ApplicationConfig.CHECK_VERSION);
+            if (checkVersion == null || Boolean.parseBoolean(checkVersion)) {
+            	analytics();
+            }
 
             if (broadcasterCacheClassName == null) {
                 logger.warn("No BroadcasterCache configured. Broadcasted message between client reconnection will be LOST. " +


### PR DESCRIPTION
This will allow the user to disable the call to AtmosphereFramework.analytics() during initialization.
