### PR TITLE
fixes issue where BlockingIOCometSupport is always used in Servlet 3.0 container 

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAsyncSupportResolver.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAsyncSupportResolver.java
@@ -297,7 +297,7 @@ public class DefaultAsyncSupportResolver implements AsyncSupportResolver {
 
         if (cs == null) {
             AsyncSupport nativeSupport = resolveNativeCometSupport(detectContainersPresent());
-            return nativeSupport == null ? new BlockingIOCometSupport(config) : nativeSupport;
+            return nativeSupport == null ? defaultCometSupport(useServlet30Async) : nativeSupport;
         } else {
             return cs;
         }


### PR DESCRIPTION
I'm running in a WebSphere 8.0 environment using the latest 2.0 snapshot (built it this morning) and I noticed that no matter what init parameters I'm use the auto detection always chooses to use BlockingIOCometSupport.  Since this is a Servlet 3.0 container I should be getting that option.  I was able to work around it by setting `org.atmosphere.cpr.asyncSupport` directly to `org.atmosphere.container.Servlet30CometSupport`, however, I thought  I'd look into why the issue was happening and made the appropriate change.

Basically, whenever there is no web socket support and no native comet support the code was just defaulting to BlockingIOCometSupport rather than checking to see if Servlet30CometSupport could be used instead.
