### PR TITLE
Fixes #1234; defaultCometSupport expects a boolean indicating if blocking is preferred

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAsyncSupportResolver.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAsyncSupportResolver.java
@@ -297,7 +297,7 @@ public class DefaultAsyncSupportResolver implements AsyncSupportResolver {
 
         if (cs == null) {
             AsyncSupport nativeSupport = resolveNativeCometSupport(detectContainersPresent());
-            return nativeSupport == null ? defaultCometSupport(useServlet30Async) : nativeSupport;
+            return nativeSupport == null ? defaultCometSupport(defaultToBlocking) : nativeSupport;
         } else {
             return cs;
         }


### PR DESCRIPTION
Fixes a logic error in `DefaultAsyncSupportResolver` that was introduced in pull request #1223 and was reported in issue #1234.
