### PR TITLE
Fixes #1262 - changes the check class for Tomcat 7 Websocket support.

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAsyncSupportResolver.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAsyncSupportResolver.java
@@ -89,7 +89,7 @@ public class DefaultAsyncSupportResolver implements AsyncSupportResolver {
     public final static String SERVLET_30 = "javax.servlet.AsyncListener";
     public final static String GLASSFISH_V2 = "com.sun.enterprise.web.PEWebContainer";
     public final static String TOMCAT_7 = "org.apache.catalina.comet.CometFilterChain";
-    public final static String TOMCAT_WEBSOCKET = "org.apache.catalina.websocket.WebSocketServlet";
+    public final static String TOMCAT_WEBSOCKET = "org.apache.coyote.http11.upgrade.UpgradeInbound";
     public final static String TOMCAT = "org.apache.coyote.http11.Http11NioProcessor";
     public final static String JBOSS_5 = "org.jboss.";
     public final static String JETTY = "org.mortbay.util.ajax.Continuation";


### PR DESCRIPTION
The check for the WebSocketServlet class is replaced with a check for the UpgradeInbound class in the check for support of Tomcat 7 Websockets.
