### PR TITLE
fix compat bundles's import and export

### DIFF
--- a/modules/compat-jbossweb/pom.xml
+++ b/modules/compat-jbossweb/pom.xml
@@ -33,9 +33,12 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Import-Package>*</Import-Package>
+                        <Import-Package>
+                            org.jboss.servlet.http.*;version="0.0",
+                            *
+                        </Import-Package>
                         <Export-Package>
-                            org.jboss.servlet.http.*,
+                            org.jboss.servlet.http.*;version="0.0",
                         </Export-Package>
                     </instructions>
                 </configuration>

--- a/modules/compat-tomcat/pom.xml
+++ b/modules/compat-tomcat/pom.xml
@@ -33,9 +33,12 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Import-Package>*</Import-Package>
+                        <Import-Package>
+                          org.apache.catalina.*;version="0.0",
+                          *
+                        </Import-Package>
                         <Export-Package>
-                            org.apache.catalina.*
+                            org.apache.catalina.*;version="0.0"
                         </Export-Package>
                     </instructions>
                 </configuration>

--- a/modules/compat-tomcat7/pom.xml
+++ b/modules/compat-tomcat7/pom.xml
@@ -33,9 +33,12 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Import-Package>*</Import-Package>
+                        <Import-Package>
+                            org.apache.catalina.comet.*;version="0.0",
+                            *
+                        </Import-Package>
                         <Export-Package>
-                            org.apache.catalina.comet.*
+                            org.apache.catalina.comet.*;version="0.0"
                         </Export-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
for 
issue 1276
1.0.16 compat bundles importing 2.0 version and exporting 0.0 of the corresponding package
