### PR TITLE
Fixes a potential NullPointerException when session is destroyed

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/SessionSupport.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/SessionSupport.java
@@ -39,12 +39,15 @@ public class SessionSupport implements HttpSessionListener {
         logger.trace("Session destroyed");
         try {
             HttpSession s = se.getSession();
-            for (Broadcaster b : BroadcasterFactory.getDefault().lookupAll()) {
-                for (AtmosphereResource r : b.getAtmosphereResources()) {
-                    if (r.session() != null && r.session().getId().equals(s.getId())) {
-                        AtmosphereResourceImpl.class.cast(r).session(null);
+            BroadcasterFactory factory = BroadcasterFactory.getDefault();
+            if (factory != null) {
+               for (Broadcaster b : factory.lookupAll()) {
+                    for (AtmosphereResource r : b.getAtmosphereResources()) {
+                        if (r.session() != null && r.session().getId().equals(s.getId())) {
+                            AtmosphereResourceImpl.class.cast(r).session(null);
+                        }
                     }
-                }
+                } 
             }
         } catch (Throwable t) {
             logger.warn("", t);


### PR DESCRIPTION
Every so often I'm seeing the following stacktrace in my logs:

```
java.lang.NullPointerException
    at org.atmosphere.cpr.SessionSupport.sessionDestroyed(SessionSupport.java:42)
    at com.ibm.ws.session.http.HttpSessionObserver.sessionDestroyed(HttpSessionObserver.java:179)
    at com.ibm.ws.session.SessionEventDispatcher.sessionDestroyed(SessionEventDispatcher.java:160)
    at com.ibm.ws.session.StoreCallback.sessionInvalidated(StoreCallback.java:126)
    at com.ibm.ws.session.store.memory.MemorySession.invalidate(MemorySession.java:232)
    at com.ibm.ws.session.store.memory.MemorySession.invalidate(MemorySession.java:878)
    at com.ibm.ws.session.store.memory.MemorySession.callInvalidateFromInternalInvalidate(MemorySession.java:864)
    at com.ibm.ws.session.store.memory.MemorySession.internalInvalidate(MemorySession.java:780)
    at com.ibm.ws.session.store.memory.MemoryStore.invalidateAllMemorySessions(MemoryStore.java:495)
    at com.ibm.ws.session.store.memory.MemoryStore.stop(MemoryStore.java:563)
    at com.ibm.ws.session.SessionContext.stop(SessionContext.java:737)
    at com.ibm.ws.session.WsSessionContext.stop(WsSessionContext.java:340)
    at com.ibm.ws.webcontainer.webapp.WebApp.destroy(WebApp.java:3015)
    at com.ibm.ws.webcontainer.webapp.WebAppImpl.destroy(WebAppImpl.java:1287)
    at com.ibm.ws.container.AbstractContainer.destroy(AbstractContainer.java:75)
    at com.ibm.ws.webcontainer.webapp.WebGroup.destroy(WebGroup.java:228)
    at com.ibm.ws.webcontainer.webapp.WebGroup.removeWebApplication(WebGroup.java:269)
    at com.ibm.ws.webcontainer.VirtualHost.removeWebApplication(VirtualHost.java:297)
    at com.ibm.ws.webcontainer.VirtualHostImpl.removeWebApplication(VirtualHostImpl.java:211)
    at com.ibm.ws.webcontainer.WSWebContainer.removeWebApplication(WSWebContainer.java:820)
    at com.ibm.ws.webcontainer.component.WebContainerImpl.uninstall(WebContainerImpl.java:454)
    at com.ibm.ws.webcontainer.component.WebContainerImpl.stop(WebContainerImpl.java:725)
    at com.ibm.ws.runtime.component.ApplicationMgrImpl.stop(ApplicationMgrImpl.java:1198)
    at com.ibm.ws.runtime.component.DeployedApplicationImpl.fireDeployedObjectStop(DeployedApplicationImpl.java:1374)
    at com.ibm.ws.runtime.component.DeployedModuleImpl.stop(DeployedModuleImpl.java:671)
    at com.ibm.ws.runtime.component.DeployedApplicationImpl.stop(DeployedApplicationImpl.java:1148)
    at com.ibm.ws.runtime.component.ApplicationMgrImpl.stopApplication(ApplicationMgrImpl.java:949)
    at com.ibm.ws.runtime.component.ApplicationMgrImpl.stop(ApplicationMgrImpl.java:902)
    at com.ibm.ws.runtime.component.ContainerHelper.stopComponent(ContainerHelper.java:476)
    at com.ibm.ws.runtime.component.ContainerHelper.stopComponents(ContainerHelper.java:460)
    at com.ibm.ws.runtime.component.ContainerImpl.stopComponents(ContainerImpl.java:650)
    at com.ibm.ws.runtime.component.ContainerImpl.stop(ContainerImpl.java:638)
    at com.ibm.ws.runtime.component.ApplicationServerImpl.stop(ApplicationServerImpl.java:263)
    at com.ibm.ws.runtime.component.ContainerHelper.stopComponent(ContainerHelper.java:476)
    at com.ibm.ws.runtime.component.ContainerHelper.stopComponents(ContainerHelper.java:460)
    at com.ibm.ws.runtime.component.ContainerImpl.stopComponents(ContainerImpl.java:650)
    at com.ibm.ws.runtime.component.ContainerImpl.stop(ContainerImpl.java:638)
    at com.ibm.ws.runtime.component.ServerImpl.stop(ServerImpl.java:615)
    at com.ibm.ws.runtime.component.ServerCollaborator$ShutdownHook$1.run(ServerCollaborator.java:860)
    at com.ibm.ws.security.auth.ContextManagerImpl.runAs(ContextManagerImpl.java:5369)
    at com.ibm.ws.security.auth.ContextManagerImpl.runAsSystem(ContextManagerImpl.java:5585)
    at com.ibm.ws.runtime.component.ServerCollaborator$ShutdownHook.run(ServerCollaborator.java:850)
    at com.ibm.ws.runtime.component.ServerCollaborator$StopAction.alarm(ServerCollaborator.java:809)
    at com.ibm.ejs.util.am._Alarm.run(_Alarm.java:133)
    at com.ibm.ws.util.ThreadPool$Worker.run(ThreadPool.java:1691)
```

This should fix it.
