### PR TITLE
Passing HttpServletRequest to the WebSocketProcessor#handshake in Glassfish 3.x

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/GlassFishWebSocketHandler.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/GlassFishWebSocketHandler.java
@@ -19,6 +19,7 @@ import com.sun.grizzly.tcp.Request;
 import com.sun.grizzly.websockets.DataFrame;
 import com.sun.grizzly.websockets.DefaultWebSocket;
 import com.sun.grizzly.websockets.ProtocolHandler;
+import com.sun.grizzly.websockets.ServerNetworkHandler;
 import com.sun.grizzly.websockets.WebSocket;
 import com.sun.grizzly.websockets.WebSocketApplication;
 import com.sun.grizzly.websockets.WebSocketListener;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRegistration;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;


### PR DESCRIPTION
By the time the server reaches the handshake method, the clietn receives onOpen notification.
If you write any error result code and status message to the request and than return "false" from the handshake method, the client websocket is closed - onClose callback is called , but no status code or error message is delivered to the client.
