### PR TITLE
Method correction: String guestServletPath(AtmosphereFramework, String)

### DIFF
--- a/modules/cpr/src/test/java/org/atmosphere/util/IOUtilsTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/util/IOUtilsTest.java
@@ -1,0 +1,30 @@
+package org.atmosphere.util;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Created by Romain on 17/03/14.
+ */
+public class IOUtilsTest {
+
+    @Test
+    public void testGetCleanedServletPath() {
+        String testFullPath;
+        String testCleanedPath;
+
+        testFullPath = "/foo/bar/*";
+        testCleanedPath = IOUtils.getCleanedServletPath(testFullPath);
+        assertEquals(testCleanedPath, "/foo/bar");
+
+        testFullPath = "foo/bar/**/*";
+        testCleanedPath = IOUtils.getCleanedServletPath(testFullPath);
+        assertEquals(testCleanedPath, "/foo/bar/**");
+
+        testFullPath = "/com.zyxabc.abc.Abc/gwtCometEvent*";
+        testCleanedPath = IOUtils.getCleanedServletPath(testFullPath);
+        assertEquals(testCleanedPath, "/com.zyxabc.abc.Abc/gwtCometEvent");
+    }
+
+}


### PR DESCRIPTION
Correction:
Bug on org.atmosphere.util.IOUtils class at String guestServletPath(AtmosphereFramework, String) #1512
- Created method getCleanedServletPath to remove trailling slashes and wildcards from a URL
- Created associated test
