### PR TITLE
#1541: wrong version range of catalina in atmosphere-runtime bundle

### DIFF
--- a/modules/cpr/pom.xml
+++ b/modules/cpr/pom.xml
@@ -39,8 +39,8 @@
                         <Import-Package>
                             com.sun*;resolution:=optional,
                             org.glassfish.grizzly*;resolution:=optional,
-                            org.apache.catalina*;resolution:=optional,
-                            org.apache.tomcat*;resolution:=optional;version="0.0",
+                            org.apache.catalina*;resolution:=optional;version="[6.0,9)",
+                            org.apache.tomcat*;resolution:=optional;version="[6.0,9)",
                             org.eclipse.jetty.continuation;resolution:=optional;version="[7.6,9)",
                             org.eclipse.jetty.websocket;resolution:=optional;version="[7.6,9)",
                             org.eclipse.jetty*;resolution:=optional,


### PR DESCRIPTION
2.1.x version
