### PR TITLE
Add support for @PathVariable annotation in ManagedService

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/config/managed/ManagedServiceInterceptor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/config/managed/ManagedServiceInterceptor.java
@@ -16,6 +16,7 @@
 package org.atmosphere.config.managed;
 
 import org.atmosphere.config.service.ManagedService;
+import org.atmosphere.config.service.PathVariable;
 import org.atmosphere.config.service.Singleton;
 import org.atmosphere.cpr.AtmosphereFramework;
 import org.atmosphere.cpr.AtmosphereRequest;
@@ -23,6 +24,11 @@ import org.atmosphere.cpr.FrameworkConfig;
 import org.atmosphere.handler.AnnotatedProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Handle {@link Singleton} for {@link ManagedService} processing.
@@ -47,7 +53,51 @@ public class ManagedServiceInterceptor extends ServiceInterceptor {
                                 boolean singleton = ap.target().getClass().getAnnotation(Singleton.class) != null;
                                 if (!singleton) {
                                     ManagedAtmosphereHandler h = config.framework().newClassInstance(ManagedAtmosphereHandler.class, ManagedAtmosphereHandler.class);
-                                    h.configure(config, config.framework().newClassInstance(Object.class, ap.target().getClass()));
+
+                                    final Object o = config.framework().newClassInstance(Object.class, ap.target().getClass());
+                                    h.configure(config, o);
+
+                                    /* begin @PathVariable annotations processing */
+
+                                    /* first, split paths at slashes and map {{parameter names}} to values from path */
+                                    logger.debug("Path: {}, targetPath: {}", path, targetPath);
+                                    String[] inParts = path.split("/");
+                                    String[] outParts = targetPath.split("/");
+                                    Map<String, String> annotatedPathVars = new HashMap<String, String>();
+                                    int len = Math.min(outParts.length, inParts.length);
+                                    for (int i = 0; i < len; i++) {
+                                        String s = outParts[i];
+                                        if (s.startsWith("{") && s.endsWith("}")) {
+                                            /* we remove braces from string and put it to our map */
+                                            annotatedPathVars.put(s.substring(1, s.length()-1), inParts[i]);
+                                            logger.debug("Putting PathVar pair: {} -> {}", s.substring(1, s.length()-1), inParts[i]);
+                                        }
+                                    }
+
+                                    /* now look for appropriate annotations and fill the variables accordingly */
+                                    for (Field field : o.getClass().getDeclaredFields()) {
+                                        if (field.isAnnotationPresent(PathVariable.class)) {
+                                            PathVariable annotation = field.getAnnotation(PathVariable.class);
+                                            String name = annotation.value();
+                                            if (name.isEmpty()) {
+                                                name = field.getName();
+                                            }
+                                            if (annotatedPathVars.containsKey(name)) {
+                                                try {
+                                                    logger.debug("Annotating field {}", name);
+                                                    field.setAccessible(true);
+                                                    field.set(o, annotatedPathVars.get(name));
+                                                } catch (Exception e) {
+                                                    logger.error("Error processing @PathVariable annotation", e);
+                                                }
+                                            } else {
+                                                logger.error("No path marker found for PathVariable {}, class {}", field.getName(), o.getClass());
+                                            }
+                                        }
+                                    }
+
+                                    /* end @PathVariable annotations processing */
+
                                     config.framework().addAtmosphereHandler(path, h,
                                             config.getBroadcasterFactory().lookup(a.broadcaster(), path, true), w.interceptors);
                                 } else {

--- a/modules/cpr/src/main/java/org/atmosphere/config/service/PathVariable.java
+++ b/modules/cpr/src/main/java/org/atmosphere/config/service/PathVariable.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 Jeanfrancois Arcand
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.config.service;
+
+import java.lang.annotation.*;
+
+/**
+ * Use this annotation with the {@link org.atmosphere.config.service.ManagedService} annotation. Annotate a field which will get appropriate value when
+ * the service is instantiated for given path. The syntax of the path is the following
+ * /whatever/{varX}/.../whatever/.../{varY}/...
+ * The @PathVariable annotation may be given a name, otherwise verbatim name of field is used
+ * The number of slashes in the matched and matching paths shall be equal, otherwise the result is undefined.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Documented
+public @interface PathVariable {
+    /**
+	 * The URI template variable to bind to.
+	 */
+	String value() default "";
+}

--- a/modules/cpr/src/test/java/org/atmosphere/annotation/PathTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/annotation/PathTest.java
@@ -15,12 +15,7 @@
  */
 package org.atmosphere.annotation;
 
-import org.atmosphere.config.service.AtmosphereHandlerService;
-import org.atmosphere.config.service.Get;
-import org.atmosphere.config.service.ManagedService;
-import org.atmosphere.config.service.MeteorService;
-import org.atmosphere.config.service.Singleton;
-import org.atmosphere.config.service.WebSocketHandlerService;
+import org.atmosphere.config.service.*;
 import org.atmosphere.cpr.Action;
 import org.atmosphere.cpr.AsynchronousProcessor;
 import org.atmosphere.cpr.AtmosphereFramework;
@@ -393,5 +388,37 @@ public class PathTest {
         assertEquals(instanceCount, 0);
         assertNotNull(r.get());
         assertEquals(r.get(), "/singleton/ws/bar");
+    }
+
+    @ManagedService(path = "/pathVar/{a}/pathTest/{b}")
+    public final static class PathVar {
+
+
+        public PathVar() {
+            ++instanceCount;
+        }
+
+        @PathVariable
+        private String a;
+
+        @PathVariable("b")
+        private String b1;
+
+        @Get
+        public void get(AtmosphereResource resource) {
+            r.set(a+"#"+b1);
+        }
+    }
+
+    @Test
+    public void testPathVar() throws IOException, ServletException {
+        instanceCount = 0;
+
+        AtmosphereRequest request = new AtmosphereRequest.Builder().pathInfo("/pathVar/aaa/pathTest/b123").method("GET").build();
+        framework.doCometSupport(request, AtmosphereResponse.newInstance());
+        assertEquals(instanceCount, 1);
+        assertNotNull(r.get());
+        assertEquals(r.get(), "aaa#b123");
+
     }
 }


### PR DESCRIPTION
This pull request adds support for Spring-like, albeit more limited, handling of PathVariables in Managed Service. The proposed use is to treat placeholders in path passed to ManagedService annotation, for example `@ManagedService(path = "/pathVar/{a}/pathTest/{b}")`, as names of variables which will get values of those path elements. In the class code the variable should be annotated:

```
@PathVariable
private String a;
```

or, if the name is different than path component placeholder, the placeholder can be specified in the annotation (`@PathVariable("b")`).

The parsing is quite simple, so the components have to be separated with slashes, and the number of slashes in pattern and real path should be equal.
No action is performed if no annotation is present.
