### PR TITLE
Remove message ID from clientQueue when clearing the message from the cache

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cache/UUIDBroadcasterCache.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cache/UUIDBroadcasterCache.java
@@ -177,6 +177,7 @@ public class UUIDBroadcasterCache implements BroadcasterCache {
             logger.trace("Removing for AtmosphereResource {} cached message {}", uuid, message.getMessage());
             notifyRemoveCache(broadcasterId, message);
             clientQueue.getQueue().remove(message);
+            clientQueue.getIds().remove(message.getId());
         }
         return this;
     }


### PR DESCRIPTION
Fix for this issue: https://github.com/Atmosphere/atmosphere/issues/1566
