### PR TITLE
#1580 - default-web-module support

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/GlassFishWebSocketHandler.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/GlassFishWebSocketHandler.java
@@ -137,10 +137,14 @@ public class GlassFishWebSocketHandler extends WebSocketApplication {
 
     @Override
     public boolean isApplicationRequest(Request request) {
+        String path = request.requestURI().toString();
 
-        if (!request.requestURI().startsWith(config.getServletContext().getContextPath())) return false;
+        // remove contextpath from start of request, which may not happen if webapp is set as the default-web-module
+        String contextPath = config.getServletContext().getContextPath();
+        if (path.startsWith(contextPath)) {
+            path = path.substring(contextPath.length());
+        }
 
-        String path = request.requestURI().toString().substring(config.getServletContext().getContextPath().length());
         Boolean b = mapper.map(path, paths);
         return b == null? false: b;
     }


### PR DESCRIPTION
GlassFishWebSocketHandler.isApplicationRequest() returns false if the request doesn't start with the servlet contextpath. However, if the webapp is set as the default-web-module, then the request will not start with the contextpath since GlassFish strips that from the request.

To fix, we just need to ensure that the contextpath is removed from the start of the request path, instead of requiring it to be so.
