### PR TITLE
avoid unnecessary wasteful allocation of 8K per each AtmosphereRequest

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequest.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequest.java
@@ -80,7 +80,7 @@ public class AtmosphereRequest extends HttpServletRequestWrapper {
     private final AtomicBoolean destroyed = new AtomicBoolean(false);
     private boolean queryComputed = false;
     private boolean cookieComputed = false;
-    private final BufferedReader voidReader = new BufferedReader(new StringReader(""));
+    private final BufferedReader voidReader = new BufferedReader(new StringReader(""), 5);
     private final ServletInputStream voidStream = new IS(new ByteArrayInputStream(new byte[0]));
     private AtomicBoolean streamSet = new AtomicBoolean();
     private AtomicBoolean readerSet = new AtomicBoolean();


### PR DESCRIPTION
This small prevents a log of GCs simply by reducing the size of the heavily-used AtmosphereRequest, from 8192 bytes per object to just 5 bytes.
