### PR TITLE
AtmosphereRequest.toString() was broken and always returned resource().uuid().

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequest.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequest.java
@@ -1994,7 +1994,7 @@ public class AtmosphereRequest extends HttpServletRequestWrapper {
                     " pathInfo=" + getPathInfo() +
                     " requestURI=" + getRequestURI() +
                     " requestURL=" + getRequestURL() +
-                    " AtmosphereResource UUID=" + resource() != null ? resource().uuid() : "" +
+                    " AtmosphereResource UUID=" + (resource() != null ? resource().uuid() : "") +
                     " destroyable=" + b.destroyable +
                     '}';
         } catch (Exception e) {


### PR DESCRIPTION
Because of missing brackets, the ternary operator always evaluated to non null,
because it had a concatenated string on the left hand side. Thus it always
returned resource().uuid().
