### PR TITLE
remove unused atmosphere-version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -515,7 +515,6 @@
     <properties>
         <jetty-version>6.1.22</jetty-version>
         <jersey-version>1.18.1</jersey-version>
-        <atmosphere-version>2.3.0-SNAPSHOT</atmosphere-version>
         <jaxb-version>2.1</jaxb-version>
         <jackson-version>1.3.1</jackson-version>
         <junit-version>3.8.1</junit-version>


### PR DESCRIPTION
a minor PR to remove the unused atmosphere-version property to avoid any confusion in the released pom at later time.

regards, aki
