### PR TITLE
Update to fix issue when using ExecutorService instances inside of the B...

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -92,6 +92,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -930,13 +931,31 @@ public class AtmosphereFramework {
         logger.info("Shared ExecutorService supported: {}", sharedThreadPools);
 
         BroadcasterConfig bc = broadcasterFactory.lookup(Broadcaster.ROOT_MASTER, true).getBroadcasterConfig();
-        if (bc.getAsyncWriteService() != null) {
-            long max = ThreadPoolExecutor.class.cast(bc.getExecutorService()).getMaximumPoolSize();
-            logger.info("Messaging Thread Pool Size: {}",
-                    ThreadPoolExecutor.class.cast(bc.getExecutorService()).getMaximumPoolSize() == 2147483647 ? "Unlimited" : max);
-            logger.info("Async I/O Thread Pool Size: {}",
-                    ThreadPoolExecutor.class.cast(bc.getAsyncWriteService()).getMaximumPoolSize());
+        if (bc.getExecutorService() != null) {
+        	ExecutorService executorService = bc.getExecutorService();
+        	if (ThreadPoolExecutor.class.isAssignableFrom(executorService.getClass())) {
+        		long max = ThreadPoolExecutor.class.cast(executorService).getMaximumPoolSize();
+                logger.info("Messaging Thread Pool Size: {}",
+                        ThreadPoolExecutor.class.cast(executorService).getMaximumPoolSize() == 2147483647 ? "Unlimited" : max);
+        	}
+        	else {
+        		logger.info("Messaging ExecutorService Pool Size unavailable - Not instance of ThreadPoolExecutor");
+        	}
         }
+        if (bc.getAsyncWriteService() != null) {
+        	ExecutorService asyncWriteService = bc.getAsyncWriteService();
+        	if (ThreadPoolExecutor.class.isAssignableFrom(asyncWriteService.getClass())) {
+                logger.info("Async I/O Thread Pool Size: {}",
+                        ThreadPoolExecutor.class.cast(asyncWriteService).getMaximumPoolSize());
+        	}
+        	else {
+        		logger.info("Async I/O ExecutorService Pool Size unavailable - Not instance of ThreadPoolExecutor");
+        	}
+        }
+        /*if (bc.getAsyncWriteService() != null) {
+            
+            
+        }*/
         logger.info("Using BroadcasterFactory: {}", broadcasterFactory.getClass().getName());
         logger.info("Using WebSocketProcessor: {}", webSocketProcessorClassName);
 


### PR DESCRIPTION
Update to fix issue when using ExecutorService instances inside of the BroadcasterConfig which are not based on ThreadPoolExecutor.  The BroadcasterConfig & Broadcaster program to the ExecutorService interface (allowing components like Spring's ExecutorServiceAdapter to be injected).  However, the AtmosphereFramework#info() method performed casts to ThreadPoolExecutor to print diagnostic information which was causing a ClassCastException.
