### PR TITLE
Try JSR356_MAPPING_PATH param before guessing servlet path

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
@@ -114,7 +114,10 @@ public class JSR356Endpoint extends Endpoint {
             headers.put(e.getKey(), e.getValue().size() > 0 ? e.getValue().get(0) : "");
         }
 
-        String servletPath = IOUtils.guestServletPath(framework.getAtmosphereConfig());
+        String servletPath = framework.getAtmosphereConfig().getInitParameter(ApplicationConfig.JSR356_MAPPING_PATH);
+        if (servletPath == null) {
+          servletPath = IOUtils.guestServletPath(framework.getAtmosphereConfig());
+        }
 
         URI uri = session.getRequestURI();
         String[] paths = uri.getPath() != null ? uri.getPath().split("/") : new String[]{};


### PR DESCRIPTION
Otherwise incorrect path goes to the AtmosphereRequest resulting in not found AtmosphereHandler
