### PR TITLE
Fix for regression caused by 337226348c18a5e5359b3e305affb8d51aa687de

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
@@ -1262,7 +1262,7 @@ public class DefaultBroadcaster implements Broadcaster {
 
                 if (duplicate) {
                     AtmosphereResourceImpl dup = (AtmosphereResourceImpl) config.resourcesFactory().find(r.uuid());
-                    if (dup != null && dup.hashCode() != r.hashCode()) {
+                    if (dup != null && dup != r) {
                         logger.warn("Duplicate resource {}. Could be caused by a dead connection not detected by your server. Replacing the old one with the fresh one", r.uuid());
                         AtmosphereResourceImpl.class.cast(dup).dirtyClose();
                     } else {


### PR DESCRIPTION
org.atmosphere.cpr.WebSocketProcessorTest#undetectedCloseWebSocketTest
was failing as a result of previous commit
(337226348c18a5e5359b3e305affb8d51aa687de)

fixes #1743
