### PR TITLE
Use separate property for JSR356 send timeout

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/version/JSR356WebSocket.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/version/JSR356WebSocket.java
@@ -47,7 +47,7 @@ public class JSR356WebSocket extends WebSocket {
         super(config);
         this.session = session;
         // https://issues.apache.org/bugzilla/show_bug.cgi?id=56026
-        session.getAsyncRemote().setSendTimeout(config.getInitParameter(ApplicationConfig.WEBSOCKET_IDLETIME, 10 * 1000));
+        session.getAsyncRemote().setSendTimeout(config.getInitParameter(ApplicationConfig.WEBSOCKET_WRITE_TIMEOUT, 60 * 1000));
     }
 
     @Override

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
@@ -197,6 +197,14 @@ public interface ApplicationConfig {
      */
     String WEBSOCKET_IDLETIME = "org.atmosphere.websocket.maxIdleTime";
     /**
+     * Timeout of JSR356 write operation.
+     * See {@link javax.websocket.RemoteEndpoint.Async#setSendTimeout(long)}
+     * <p/>
+     * Default: 1 minute<br>
+     * Value: org.atmosphere.websocket.writeTimeout
+     */
+    String WEBSOCKET_WRITE_TIMEOUT = "org.atmosphere.websocket.writeTimeout";
+    /**
      * Tell Atmosphere the WebSocket write buffer size.
      * <p/>
      * Default: 8192<br>


### PR DESCRIPTION
It seems that WEBSOCKET_IDLETIME is used to specify timeout of the socket session. 
For the write operation we need another property.
