### PR TITLE
Log stacktraces with DEBUG level

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceImpl.java
@@ -631,7 +631,8 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
         } catch (Throwable t) {
             AtmosphereResourceEventImpl.class.cast(event).setThrowable(t);
             if (event.isSuspended()) {
-                logger.warn("Exception during suspend() operation {}", t);
+                logger.warn("Exception during suspend() operation {}", t.toString());
+                logger.debug("", t);
                 broadcaster.removeAtmosphereResource(this);
                 if (config.getBroadcasterFactory() != null) {
                     config.getBroadcasterFactory().removeAllAtmosphereResource(this);


### PR DESCRIPTION
Otherwise there are some logs like this:

```
[2014-12-04 16:14:23,933]   WARN [nio-80-exec-156] - ere.cpr.AtmosphereResourceImpl - Exception during suspend() operation {} 
java.lang.RuntimeException: java.io.IOException: An established connection was aborted by the software in your host machine
    at org.atmosphere.cpr.AtmosphereResponse.write(AtmosphereResponse.java:919)
    at org.atmosphere.cpr.AtmosphereResponse.write(AtmosphereResponse.java:877)
    at org.atmosphere.interceptor.JavaScriptProtocol$1.onSuspend(JavaScriptProtocol.java:145)
    at org.atmosphere.cpr.AtmosphereResourceImpl.onSuspend(AtmosphereResourceImpl.java:688)
    at org.atmosphere.cpr.AtmosphereResourceImpl.notifyListeners(AtmosphereResourceImpl.java:622)
    at org.atmosphere.cpr.AtmosphereResourceImpl.notifyListeners(AtmosphereResourceImpl.java:595)
    at org.atmosphere.cpr.AtmosphereResourceImpl.suspend(AtmosphereResourceImpl.java:414)
    at org.atmosphere.cpr.AtmosphereResourceImpl.suspend(AtmosphereResourceImpl.java:321)
    at jetbrains.buildServer.push.impl.atmosphere.AtmosphereHandler.onRequest(AtmosphereHandler.java:60)
    at org.atmosphere.cpr.AsynchronousProcessor.action(AsynchronousProcessor.java:205)
    at org.atmosphere.cpr.AsynchronousProcessor.suspended(AsynchronousProcessor.java:104)
    at org.atmosphere.container.TomcatWebSocketUtil.doService(TomcatWebSocketUtil.java:154)
    at org.atmosphere.container.Tomcat7Servlet30SupportWithWebSocket.service(Tomcat7Servlet30SupportWithWebSocket.java:62)
    at org.atmosphere.cpr.AtmosphereFramework.doCometSupport(AtmosphereFramework.java:2077)
    at org.atmosphere.websocket.DefaultWebSocketProcessor.dispatch(DefaultWebSocketProcessor.java:570)
    at org.atmosphere.websocket.DefaultWebSocketProcessor.open(DefaultWebSocketProcessor.java:215)
    at org.atmosphere.container.TomcatWebSocketHandler.onOpen(TomcatWebSocketHandler.java:72)
    at org.apache.catalina.websocket.StreamInbound.onUpgradeComplete(StreamInbound.java:251)
    at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:646)
    at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1736)
    at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1695)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: An established connection was aborted by the software in your host machine
    at sun.nio.ch.SocketDispatcher.write0(Native Method)
    at sun.nio.ch.SocketDispatcher.write(SocketDispatcher.java:51)
    at sun.nio.ch.IOUtil.writeFromNativeBuffer(IOUtil.java:93)
    at sun.nio.ch.IOUtil.write(IOUtil.java:65)
    at sun.nio.ch.SocketChannelImpl.write(SocketChannelImpl.java:487)
    at org.apache.tomcat.util.net.NioChannel.write(NioChannel.java:128)
    at org.apache.tomcat.util.net.NioBlockingSelector.write(NioBlockingSelector.java:101)
    at org.apache.tomcat.util.net.NioSelectorPool.write(NioSelectorPool.java:174)
    at org.apache.coyote.http11.upgrade.UpgradeNioProcessor.writeToSocket(UpgradeNioProcessor.java:226)
    at org.apache.coyote.http11.upgrade.UpgradeNioProcessor.write(UpgradeNioProcessor.java:85)
    at org.apache.coyote.http11.upgrade.UpgradeOutbound.write(UpgradeOutbound.java:44)
    at org.apache.catalina.websocket.WsOutbound.doWriteBytes(WsOutbound.java:477)
    at org.apache.catalina.websocket.WsOutbound.doWriteText(WsOutbound.java:529)
    at org.apache.catalina.websocket.WsOutbound.writeTextMessage(WsOutbound.java:221)
    at org.atmosphere.container.version.TomcatWebSocket.write(TomcatWebSocket.java:57)
    at org.atmosphere.websocket.WebSocket.write(WebSocket.java:222)
    at org.atmosphere.websocket.WebSocket.write(WebSocket.java:187)
    at org.atmosphere.websocket.WebSocket.write(WebSocket.java:42)
    at org.atmosphere.cpr.AtmosphereResponse$2.write(AtmosphereResponse.java:515)
    at org.atmosphere.cpr.AtmosphereResponse.write(AtmosphereResponse.java:909)
    ... 24 more

```

Seems that it's ok.
