### PR TITLE
Fix problem with Chrome 33 and empty headers

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -2091,7 +2091,6 @@ public class AtmosphereFramework {
             res.setHeader(HeaderConfig.X_FIRST_REQUEST, "true");
             res.setHeader(X_ATMOSPHERE_TRACKING_ID, s);
         } else {
-            res.setHeader(HeaderConfig.X_FIRST_REQUEST, null);
             // This may breaks 1.0.0 application because the WebSocket's associated AtmosphereResource will
             // all have the same UUID, and retrieving the original one for WebSocket, so we don't set it at all.
             // Null means it is not an HTTP request.


### PR DESCRIPTION
Chrome 33 can't handle empty headers in WS upgrade responses it seems. The result is an "Invalid UTF-8 sequence in header" error.
