### PR TITLE
#1857 make sure system-wide interceptors are configured before auto configuring service.

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -869,6 +869,8 @@ public class AtmosphereFramework {
 
             installAnnotationProcessor(servletConfig);
 
+            configureAtmosphereInterceptor(servletConfig);
+
             autoConfigureService(servletConfig.getServletContext());
 
             // Reconfigure in case an annotation changed the default.
@@ -884,7 +886,6 @@ public class AtmosphereFramework {
             configureWebDotXmlAtmosphereHandler(servletConfig);
             asyncSupport.init(servletConfig);
             initAtmosphereHandler(servletConfig);
-            configureAtmosphereInterceptor(servletConfig);
             analytics();
 
             // http://java.net/jira/browse/ATMOSPHERE-157


### PR DESCRIPTION
My previous commit did not fully resolve the issue since the system-wide interceptors were loaded after service gets auto-configured with default interceptors. 