### PR TITLE
#1857 populate excludedInterceptors in doInitParams

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -1150,11 +1150,6 @@ public class AtmosphereFramework {
         if (s == null || !"true".equalsIgnoreCase(s)) {
             logger.info("Installing Default AtmosphereInterceptors");
 
-            s = sc.getInitParameter(ApplicationConfig.DISABLE_ATMOSPHEREINTERCEPTORS);
-            if (s != null) {
-                excludedInterceptors.addAll(Arrays.asList(s.trim().replace(" ", "").split(",")));
-            }
-
             // We must reposition
             LinkedList<AtmosphereInterceptor> copy = null;
             if (!interceptors.isEmpty()) {
@@ -1449,6 +1444,11 @@ public class AtmosphereFramework {
         s = sc.getInitParameter(ApplicationConfig.DEFAULT_SERIALIZER);
         if (s != null) {
             defaultSerializerClassName = s;
+        }
+
+        s = sc.getInitParameter(ApplicationConfig.DISABLE_ATMOSPHEREINTERCEPTORS);
+        if (s != null) {
+            excludedInterceptors.addAll(Arrays.asList(s.trim().replace(" ", "").split(",")));
         }
     }
 


### PR DESCRIPTION
Moved some code to populate excludedInterceptors from configureAtmosphereInterceptor(ServletConfig sc) to doInitParams(ServletConfig sc, boolean reconfigure). This way, excludedInterceptors is populated early enough and AnnotationUtil can pick it up.