### PR TITLE
Systematic creation of a ROOT broadcaster in the info() conflicts with other servlets

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -925,8 +925,9 @@ public class AtmosphereFramework {
                     AtmosphereFramework.this.destroy();
                 }
             });
-
-            info();
+            if (logger.isInfoEnabled()) {
+            	info();
+            }
         } catch (Throwable t) {
             logger.error("Failed to initialize Atmosphere Framework", t);
 
@@ -1041,27 +1042,30 @@ public class AtmosphereFramework {
         logger.info("Broadcaster Polling Wait Time {}", s == null ? DefaultBroadcaster.POLLING_DEFAULT : s);
         logger.info("Shared ExecutorService supported: {}", sharedThreadPools);
 
-        BroadcasterConfig bc = broadcasterFactory.lookup(Broadcaster.ROOT_MASTER, true).getBroadcasterConfig();
-        if (bc.getExecutorService() != null) {
-            ExecutorService executorService = bc.getExecutorService();
-            if (ThreadPoolExecutor.class.isAssignableFrom(executorService.getClass())) {
-                long max = ThreadPoolExecutor.class.cast(executorService).getMaximumPoolSize();
-                logger.info("Messaging Thread Pool Size: {}",
-                        ThreadPoolExecutor.class.cast(executorService).getMaximumPoolSize() == 2147483647 ? "Unlimited" : max);
-            } else {
-                logger.info("Messaging ExecutorService Pool Size unavailable - Not instance of ThreadPoolExecutor");
+        Iterator<Broadcaster> bcIter = broadcasterFactory.lookupAll().iterator();
+        if (bcIter.hasNext()) {
+        	BroadcasterConfig bc = bcIter.next().getBroadcasterConfig();
+            if (bc.getExecutorService() != null) {
+                ExecutorService executorService = bc.getExecutorService();
+                if (ThreadPoolExecutor.class.isAssignableFrom(executorService.getClass())) {
+                    long max = ThreadPoolExecutor.class.cast(executorService).getMaximumPoolSize();
+                    logger.info("Messaging Thread Pool Size: {}",
+                            ThreadPoolExecutor.class.cast(executorService).getMaximumPoolSize() == 2147483647 ? "Unlimited" : max);
+                } else {
+                    logger.info("Messaging ExecutorService Pool Size unavailable - Not instance of ThreadPoolExecutor");
+                }
+            }
+            if (bc.getAsyncWriteService() != null) {
+                ExecutorService asyncWriteService = bc.getAsyncWriteService();
+                if (ThreadPoolExecutor.class.isAssignableFrom(asyncWriteService.getClass())) {
+                    logger.info("Async I/O Thread Pool Size: {}",
+                            ThreadPoolExecutor.class.cast(asyncWriteService).getMaximumPoolSize());
+                } else {
+                    logger.info("Async I/O ExecutorService Pool Size unavailable - Not instance of ThreadPoolExecutor");
+                }
             }
         }
 
-        if (bc.getAsyncWriteService() != null) {
-            ExecutorService asyncWriteService = bc.getAsyncWriteService();
-            if (ThreadPoolExecutor.class.isAssignableFrom(asyncWriteService.getClass())) {
-                logger.info("Async I/O Thread Pool Size: {}",
-                        ThreadPoolExecutor.class.cast(asyncWriteService).getMaximumPoolSize());
-            } else {
-                logger.info("Async I/O ExecutorService Pool Size unavailable - Not instance of ThreadPoolExecutor");
-            }
-        }
         logger.info("Using BroadcasterFactory: {}", broadcasterFactory.getClass().getName());
         logger.info("Using AtmosphereResurceFactory: {}", arFactory.getClass().getName());
         logger.info("Using WebSocketProcessor: {}", webSocketProcessorClassName);


### PR DESCRIPTION
In two occurrences, the systematic creation of a "/\*" broadcaster has created conflits:
 - when integration Atmosphere in an existing application with servlet already mapped: the "/\*" servlet mapping conflicts with all other mappings, even when the Atmosphere servlet is mapped to a subpath ("/atmosphere" for example);
 - when activating the JGroups Atmosphere functionality for a @ManagedService, the created "/\*" conflicts with the JGroups broadcaster, generating a lot of warning from the latter saying the message is not aimed at the broadcaster path, but to "/\*"