### PR TITLE
Fix some merge issues w/ state recovery interceptor.

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/interceptor/AtmosphereResourceStateRecovery.java
+++ b/modules/cpr/src/main/java/org/atmosphere/interceptor/AtmosphereResourceStateRecovery.java
@@ -287,7 +287,11 @@ public class AtmosphereResourceStateRecovery implements AtmosphereInterceptor {
                 cache = b.getBroadcasterConfig().getBroadcasterCache();
                 List<Object> t = cache.retrieveFromCache(b.getID(), r.uuid());
 
-                cachedMessages = b.getBroadcasterConfig().applyFilters(r, t);
+                t = b.getBroadcasterConfig().applyFilters(r, t);
+                if (t.size() > 0) {
+                    logger.trace("Found Cached Messages For AtmosphereResource {} with Broadcaster {}", r.uuid(), broadcasterID);
+                    cachedMessages.addAll(t);
+                }
             } else {
                 logger.trace("Broadcaster {} is no longer available for {}", broadcasterID, r);
             }


### PR DESCRIPTION
* Iterate all the tracker IDs, filter, and then add any filtered
  messages to the same cached message list to process.

Inside the loop over the broadcaster IDs, the cachedMessages keeps getting re-assigned to the results of filtering the messages for that specific broadcaster ID.

It seems to me the real intent is the following:

* Iterate broadcaster IDs.
* For a given ID, lookup cached messages.
* Filter those cached messages.
* If any message are left after filtering, add to our aggregate list.
* Return the aggregate list of all filtered messages to the calling code.

This fix seems to restore that logic.

Any chance we can get this merged into the 2.2.x branch as well for a release any time soon? This state recovery being broken is a blocker for our project.

Thanks again.