### PR TITLE
AtmosphereSession: treat long-polling resources as single-use

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereSession.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereSession.java
@@ -42,10 +42,12 @@ public class AtmosphereSession {
     protected final Semaphore latch = new Semaphore(1);
     protected BroadcasterListenerAdapter broadcasterListener;
     protected Broadcaster[] relatedBroadcasters;
+    protected final boolean usesLongPolling;
 
     public AtmosphereSession(final AtmosphereResource r, Broadcaster... broadcasters) {
         this.uuid = r.uuid();
         this.relatedBroadcasters = broadcasters;
+        this.usesLongPolling = AtmosphereResource.TRANSPORT.LONG_POLLING == r.transport();
         resource.set(r);
 
         broadcasterListener = new BroadcasterListenerAdapter() {
@@ -109,11 +111,18 @@ public class AtmosphereSession {
      * Retrieve the {@link AtmosphereResource} associated with this session. If there is no {@link AtmosphereResource}
      * associated, wait until the {@link AtmosphereResource} is retrieved.
      *
+     * <p>If the resource uses long polling as its transport, this method treats the resource as a single use connection
+     * and will make subsequent callers wait until the client reconnects and the {@link #broadcasterListener}'s
+     * {@link BroadcasterListenerAdapter#onAddAtmosphereResource} method gets called again.</p>
+     *
+     * <p>WARNING: Use this method with long polling only if you intend to broadcast to the returned resource. If no broadcast is made,
+     * the client won't have to reconnect, the resource won't get re-added, and any subsequent calls will have to wait until the timeout is reached.</p>
+     *
      * @param timeInSecond The timeToWait before continuing the execution
-     * @return an {@link AtmosphereResource}
+     * @return an {@link AtmosphereResource} or {@code null} if the resource was not set and it didn't get set during the timeout
      */
     public AtmosphereResource tryAcquire(int timeInSecond) throws InterruptedException {
-        if (resource.get() == null) {
+        if (usesLongPolling || resource.get() == null) {
             latch.tryAcquire(timeInSecond, TimeUnit.SECONDS);
         }
         return resource.get();


### PR DESCRIPTION
Hello,

this change will treat long-polling resources as single-use which means that subsequent calls to tryAcquire(t) will have to wait until the client reconnects. This should avoid the problem where the same resource is used by e.g. two threads at the same time, to write something to one client.
It shouldn't break the functionality for others who use Comet / SSE / WebSockets but if need be, I could create a new method with this behavior to keep backwards-compatibility.

Could this get merged into 2.2.x / 2.3.x?