### PR TITLE
Create new instances when broadcaster is defined on config

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -1222,8 +1222,9 @@ public class AtmosphereFramework {
             }
 
             if (broadcasterFactoryClassName != null) {
-                broadcasterFactory = newClassInstance(BroadcasterFactory.class,
-                        (Class<BroadcasterFactory>) IOUtils.loadClass(getClass(), broadcasterFactoryClassName));
+                if (broadcasterFactory == null)
+                    broadcasterFactory = newClassInstance(BroadcasterFactory.class,
+                            (Class<BroadcasterFactory>) IOUtils.loadClass(getClass(), broadcasterFactoryClassName));
             }
 
             if (broadcasterFactory == null) {


### PR DESCRIPTION
When set:
```java atmosphereServlet.setInitParameter(ApplicationConfig.BROADCASTER_FACTORY, RedisBroadcasterFactory.class.getName());```

Create new instances of Factory.
