### PR TITLE
#2018: [WebLogic] 12.1.3 BlockingIOCometSupport selected

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAsyncSupportResolver.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAsyncSupportResolver.java
@@ -227,17 +227,15 @@ public class DefaultAsyncSupportResolver implements AsyncSupportResolver {
      * The class has to have a visible constructor with the signature (@link {AtmosphereConfig}).
      *
      * @param targetClass
-     * @return an instance of the specified class
+     * @return an instance of the specified class or null if the class cannot be instantiated
      */
     public AsyncSupport newCometSupport(final Class<? extends AsyncSupport> targetClass) {
         try {
             return (AsyncSupport) targetClass.getDeclaredConstructor(new Class[]{AtmosphereConfig.class})
                     .newInstance(config);
         } catch (final Exception e) {
-            logger.error("Failed to create comet support class: {}, error: {}", targetClass, e);
-            logger.error("Switching to BlockingIO");
-
-            return new BlockingIOCometSupport(config);
+            logger.warn("Failed to create AsyncSupport class: {}, error: {}", targetClass, e);
+            return null; // All callers are expected to handle null return value
         }
     }
 

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/DefaultAsyncSupportResolverTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/DefaultAsyncSupportResolverTest.java
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) Acando AS. All rights reserved.
- * <p>
- * Licensed under the iKnowBase license. You may not use this
- * file except in compliance with the License. Contact Acando
- * AS, Oslo, Norway, to obtain a copy of the license.
- */
 package org.atmosphere.cpr;
 
 import org.atmosphere.container.Servlet30CometSupport;

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/DefaultAsyncSupportResolverTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/DefaultAsyncSupportResolverTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.atmosphere.cpr;
 
 import org.atmosphere.container.Servlet30CometSupport;

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/DefaultAsyncSupportResolverTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/DefaultAsyncSupportResolverTest.java
@@ -15,6 +15,7 @@
  */
 package org.atmosphere.cpr;
 
+import org.atmosphere.container.BlockingIOCometSupport;
 import org.atmosphere.container.Servlet30CometSupport;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -84,7 +85,7 @@ public class DefaultAsyncSupportResolverTest {
     public void testAsyncSupportClassNotFoundDefaultsToBlockingIOIfServlet30IsNotAvailable(){
         boolean useNativeIfPossible = false;
         boolean defaultToBlocking = false;
-        boolean useServlet30Async = false;
+        boolean useServlet30Async = true;
 
         // FIXME: interface method argument mismatch for AsyncSupportResolver.resolve
         // Interface:                   final boolean useNativeIfPossible, final boolean defaultToBlocking, final boolean useWebsocketIfPossible
@@ -101,10 +102,13 @@ public class DefaultAsyncSupportResolverTest {
         doReturn(null)
                 .when(defaultAsyncSupportResolver)
                 .resolveNativeCometSupport(anyList());
+        doReturn(false)
+                .when(defaultAsyncSupportResolver)
+                .testClassExists(DefaultAsyncSupportResolver.SERVLET_30);
 
         Assert.assertEquals(
                 defaultAsyncSupportResolver.resolve(useNativeIfPossible, defaultToBlocking, useServlet30Async).getClass(),
-                Servlet30CometSupport.class);
+                BlockingIOCometSupport.class);
     }
 
     class InvalidAsyncSupportClass implements AsyncSupport{

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/DefaultAsyncSupportResolverTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/DefaultAsyncSupportResolverTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Acando AS. All rights reserved.
+ * <p>
+ * Licensed under the iKnowBase license. You may not use this
+ * file except in compliance with the License. Contact Acando
+ * AS, Oslo, Norway, to obtain a copy of the license.
+ */
+package org.atmosphere.cpr;
+
+import org.atmosphere.container.Servlet30CometSupport;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class DefaultAsyncSupportResolverTest {
+
+    private AtmosphereConfig config;
+    private DefaultAsyncSupportResolver defaultAsyncSupportResolver;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        config = new AtmosphereFramework().getAtmosphereConfig();
+        defaultAsyncSupportResolver = new DefaultAsyncSupportResolver(config);
+    }
+
+    @AfterMethod
+    public void unSet() throws Exception {
+        config.destroy();
+    }
+
+    @Test
+    public void testNullIfNonInstantiableWebSocketClass(){
+        Assert.assertNull(defaultAsyncSupportResolver.newCometSupport(InvalidAsyncSupportClass.class));
+    }
+
+    @Test
+    public void testAsyncSupportClassNotFoundDefaultsToServlet30IfAvailable(){
+        boolean useNativeIfPossible = false;
+        boolean defaultToBlocking = false;
+        boolean useServlet30Async = true;
+
+        // FIXME: interface method argument name mismatch for AsyncSupportResolver.resolve
+        // Interface:                   final boolean useNativeIfPossible, final boolean defaultToBlocking, final boolean useWebsocketIfPossible
+        // DefaultAsyncSupportResolver:       boolean useNativeIfPossible,       boolean defaultToBlocking,       boolean useServlet30Async
+
+        // Override the container detection mechanism to use an invalid Async Support class only
+        defaultAsyncSupportResolver = spy(defaultAsyncSupportResolver);
+        List<Class<? extends AsyncSupport>> asyncSupportList = new ArrayList(){{
+            add(InvalidAsyncSupportClass.class);
+        }};
+        doReturn(asyncSupportList)
+                .when(defaultAsyncSupportResolver)
+                .detectWebSocketPresent(useNativeIfPossible, useServlet30Async);
+        doReturn(null)
+                .when(defaultAsyncSupportResolver)
+                .resolveNativeCometSupport(anyList());
+
+        Assert.assertEquals(
+                defaultAsyncSupportResolver.resolve(useNativeIfPossible, defaultToBlocking, useServlet30Async).getClass(),
+                Servlet30CometSupport.class);
+    }
+
+    @Test
+    public void testAsyncSupportClassNotFoundDefaultsToBlockingIOIfServlet30IsNotAvailable(){
+        boolean useNativeIfPossible = false;
+        boolean defaultToBlocking = false;
+        boolean useServlet30Async = false;
+
+        // FIXME: interface method argument mismatch for AsyncSupportResolver.resolve
+        // Interface:                   final boolean useNativeIfPossible, final boolean defaultToBlocking, final boolean useWebsocketIfPossible
+        // DefaultAsyncSupportResolver:       boolean useNativeIfPossible,       boolean defaultToBlocking,       boolean useServlet30Async
+
+        // Override the container detection mechanism to use an invalid Async Support class only
+        defaultAsyncSupportResolver = spy(defaultAsyncSupportResolver);
+        List<Class<? extends AsyncSupport>> asyncSupportList = new ArrayList(){{
+            add(InvalidAsyncSupportClass.class);
+        }};
+        doReturn(asyncSupportList)
+                .when(defaultAsyncSupportResolver)
+                .detectWebSocketPresent(useNativeIfPossible, useServlet30Async);
+        doReturn(null)
+                .when(defaultAsyncSupportResolver)
+                .resolveNativeCometSupport(anyList());
+
+        Assert.assertEquals(
+                defaultAsyncSupportResolver.resolve(useNativeIfPossible, defaultToBlocking, useServlet30Async).getClass(),
+                Servlet30CometSupport.class);
+    }
+
+    class InvalidAsyncSupportClass implements AsyncSupport{
+
+        public InvalidAsyncSupportClass(AtmosphereConfig config) throws InvocationTargetException {
+            throw new InvocationTargetException(new Exception(),
+                    "This is an invalid AsyncSupport class for testing purposes");
+        }
+
+        @Override
+        public String getContainerName() {
+            return null;
+        }
+
+        @Override
+        public void init(ServletConfig sc) throws ServletException {
+
+        }
+
+        @Override
+        public Action service(AtmosphereRequest req, AtmosphereResponse res) throws IOException, ServletException {
+            return null;
+        }
+
+        @Override
+        public void action(AtmosphereResource actionEvent) {
+
+        }
+
+        @Override
+        public boolean supportWebSocket() {
+            return false;
+        }
+
+        @Override
+        public AsyncSupport complete(AtmosphereResource r) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Do not return BlockingIOCometSupport in case the WebSocket class cannot be found. Callers of newCometSupport all handle null values and apply a default for AsyncSupport.

This fixes an issue on WebLogic 12.1.3 when the JSR356AsyncSupport fails. The fix will result in Servlet30CometSupport since servlet 3.0 async is available.

The fix has been tested on WebLogic 12.1.3 (now fallbacks to Servlet30). Also verified no regression for Jetty 9.3 with WebSocket (correctly resolves the WebSocket class).

Note#1: I've added a FIXME regarding AsyncSupportResolver.resolve since the parameters in the interface is named differently from the method in the implementing class DefaultAsyncSupportResolver. This should be looked at.

Note#2: I've also observed that DefaultAsyncSupportResolver.resolve(boolean, boolean) is documented as "This method is the general interface to the outside world", but as far as I can tell it is not called at all... The inferface specifies resolve(boolean, boolean, boolean). This should be looked at.