### PR TITLE
Prevent duplicate resource warning for delayed close websocket connections

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceImpl.java
@@ -88,6 +88,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
     private WebSocket webSocket;
     private final AtomicBoolean inClosingPhase = new AtomicBoolean();
     private boolean closeOnCancel = false;
+    private final AtomicBoolean isPendingClose = new AtomicBoolean();
 
     public AtmosphereResourceImpl() {
     }
@@ -533,6 +534,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
     public void reset() {
         isResumed.set(false);
         isCancelled.set(false);
+        isPendingClose.set(false);
         isInScope.set(true);
         isSuspendEvent.set(false);
         listeners.clear();
@@ -1018,5 +1020,16 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
 
     public boolean getAndSetInClosingPhase() {
         return inClosingPhase.getAndSet(true);
+    }
+
+    /**
+     * @return
+     */
+    public boolean isPendingClose () {
+        return isPendingClose.get();
+    }
+    
+    public boolean getAndSetPendingClose() {
+        return isPendingClose.getAndSet(true);
     }
 }

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
@@ -1361,8 +1361,12 @@ public class DefaultBroadcaster implements Broadcaster {
 
                 if (duplicate) {
                     AtmosphereResourceImpl dup = (AtmosphereResourceImpl) config.resourcesFactory().find(r.uuid());
-                    if (dup != null && dup != r) {
-                        logger.warn("Duplicate resource {}. Could be caused by a dead connection not detected by your server. Replacing the old one with the fresh one", r.uuid());
+                    if (dup != null && dup != r ) {
+                        if ( ! dup.isPendingClose() ) {
+                            logger.warn("Duplicate resource {}. Could be caused by a dead connection not detected by your server. Replacing the old one with the fresh one", r.uuid());
+                        } else {
+                            logger.debug("Not yet closed resource still active {}", r.uuid());
+                        }
                         AtmosphereResourceImpl.class.cast(dup).dirtyClose();
                     } else {
                         logger.debug("Duplicate resource {}", r.uuid());

--- a/modules/cpr/src/main/java/org/atmosphere/websocket/DefaultWebSocketProcessor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/websocket/DefaultWebSocketProcessor.java
@@ -633,6 +633,7 @@ public class DefaultWebSocketProcessor implements WebSocketProcessor, Serializab
                                     return null;
                                 }
                             }, ff ? (closingTime == 0 ? 1000 : closingTime) : closingTime, TimeUnit.MILLISECONDS);
+                            resource.getAndSetPendingClose();
                         } else {
                             executeClose(webSocket, closeCode);
                         }


### PR DESCRIPTION
Fix for atmosphere#2052

Although I'm not exactly sure whether the call to dirtyClose needs to be there in the delayed close case, but I don't think it hurts.

