### PR TITLE
PathParam not injected ( fixes #2080 )

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/config/managed/ManagedServiceInterceptor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/config/managed/ManagedServiceInterceptor.java
@@ -65,7 +65,7 @@ public class ManagedServiceInterceptor extends ServiceInterceptor {
 
                                 AtmosphereResourceImpl.class.cast(request.resource()).atmosphereHandler(ap);
 
-                                config.framework().addAtmosphereHandler(path, ap,
+                                config.framework().addAtmosphereHandler(targetPath, ap,
                                         config.getBroadcasterFactory().lookup(a.broadcaster(), path, true), w.interceptors);
                                 request.setAttribute(FrameworkConfig.NEW_MAPPING, "true");
                             } catch (Throwable e) {


### PR DESCRIPTION
Each resource will get a new atmosphere handler per request if path parameters are used. The injection won't be done as the required flag is set to false because of the wrong referenced variable.

This will spam the log with "Atmosphere handler created" messages. Maybe this is another bug.