### PR TITLE
Only call cancel on AtmosphereResource when closing/shutting down.

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -1789,7 +1789,7 @@ public class AtmosphereFramework {
     protected void closeAtmosphereResource() {
         for (AtmosphereResource r : config.resourcesFactory().findAll()) {
             try {
-                r.resume().close();
+                r.close();
             } catch (IOException e) {
                 logger.trace("", e);
             }

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequestImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequestImpl.java
@@ -673,12 +673,7 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
             throw ex;
         } catch (NullPointerException ex) {
             // GLASSFISH http://java.net/jira/browse/GLASSFISH-18856
-//        	try {
-				return b.request.getSession(create);
-//			} catch (Exception e) {
-//				logger.trace("", ex);
-//				return null;
-//			}
+			return b.request.getSession(create);
         } catch (RuntimeException ex) {
             // https://github.com/Atmosphere/atmosphere/issues/1974
             logger.trace("", ex);

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequestImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequestImpl.java
@@ -673,12 +673,12 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
             throw ex;
         } catch (NullPointerException ex) {
             // GLASSFISH http://java.net/jira/browse/GLASSFISH-18856
-        	try {
+//        	try {
 				return b.request.getSession(create);
-			} catch (Exception e) {
-				logger.trace("", ex);
-				return null;
-			}
+//			} catch (Exception e) {
+//				logger.trace("", ex);
+//				return null;
+//			}
         } catch (RuntimeException ex) {
             // https://github.com/Atmosphere/atmosphere/issues/1974
             logger.trace("", ex);


### PR DESCRIPTION
This prevents 2 calls to the async complete.
Also remove previous try/catch which is not needed with this fix now.

re #1974 