### PR TITLE
Code quality fix - Serializable classes should have a version id

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereServlet.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereServlet.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  */
 public class AtmosphereServlet extends HttpServlet {
 
-	private static final long serialVersionUID = 7526472295622776147L;
+    private static final long serialVersionUID = 7526472295622776146L;
     protected static final Logger logger = LoggerFactory.getLogger(AtmosphereServlet.class);
     protected final AtmosphereFrameworkInitializer initializer;
 

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereServlet.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereServlet.java
@@ -35,6 +35,7 @@ import java.io.IOException;
  */
 public class AtmosphereServlet extends HttpServlet {
 
+	private static final long serialVersionUID = 7526472295622776147L;
     protected static final Logger logger = LoggerFactory.getLogger(AtmosphereServlet.class);
     protected final AtmosphereFrameworkInitializer initializer;
 

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/MeteorServlet.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/MeteorServlet.java
@@ -44,6 +44,7 @@ import static org.atmosphere.cpr.Broadcaster.ROOT_MASTER;
  */
 public class MeteorServlet extends AtmosphereServlet {
 
+	private static final long serialVersionUID = 7526472295622776110L;
     protected static final Logger logger = LoggerFactory.getLogger(MeteorServlet.class);
 
     private Servlet delegate;

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/MeteorServlet.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/MeteorServlet.java
@@ -44,7 +44,7 @@ import static org.atmosphere.cpr.Broadcaster.ROOT_MASTER;
  */
 public class MeteorServlet extends AtmosphereServlet {
 
-	private static final long serialVersionUID = 7526472295622776110L;
+    private static final long serialVersionUID = 7526472295622776110L;
     protected static final Logger logger = LoggerFactory.getLogger(MeteorServlet.class);
 
     private Servlet delegate;

--- a/modules/cpr/src/main/java/org/atmosphere/handler/ReflectorServletProcessor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/handler/ReflectorServletProcessor.java
@@ -56,6 +56,7 @@ import java.util.Map;
  */
 public class ReflectorServletProcessor extends AbstractReflectorAtmosphereHandler {
 
+	private static final long serialVersionUID = 7526472295622776148L;
     private final static String APPLICATION_NAME = "applicationClassName";
     private static final Logger logger = LoggerFactory.getLogger(ReflectorServletProcessor.class);
 

--- a/modules/cpr/src/main/java/org/atmosphere/handler/ReflectorServletProcessor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/handler/ReflectorServletProcessor.java
@@ -56,7 +56,7 @@ import java.util.Map;
  */
 public class ReflectorServletProcessor extends AbstractReflectorAtmosphereHandler {
 
-	private static final long serialVersionUID = 7526472295622776148L;
+    private static final long serialVersionUID = 7526472295622776148L;
     private final static String APPLICATION_NAME = "applicationClassName";
     private static final Logger logger = LoggerFactory.getLogger(ReflectorServletProcessor.class);
 

--- a/modules/cpr/src/main/java/org/atmosphere/websocket/DefaultWebSocketProcessor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/websocket/DefaultWebSocketProcessor.java
@@ -89,6 +89,7 @@ import static org.atmosphere.websocket.WebSocketEventListener.WebSocketEvent.TYP
  */
 public class DefaultWebSocketProcessor implements WebSocketProcessor, Serializable, WebSocketPingPongListener {
 
+	private static final long serialVersionUID = 7526472295622776149L;
     private static final Logger logger = LoggerFactory.getLogger(DefaultWebSocketProcessor.class);
 
     private /* final */ AtmosphereFramework framework;

--- a/modules/cpr/src/main/java/org/atmosphere/websocket/DefaultWebSocketProcessor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/websocket/DefaultWebSocketProcessor.java
@@ -89,7 +89,7 @@ import static org.atmosphere.websocket.WebSocketEventListener.WebSocketEvent.TYP
  */
 public class DefaultWebSocketProcessor implements WebSocketProcessor, Serializable, WebSocketPingPongListener {
 
-	private static final long serialVersionUID = 7526472295622776149L;
+    private static final long serialVersionUID = 7526472295622776149L;
     private static final Logger logger = LoggerFactory.getLogger(DefaultWebSocketProcessor.class);
 
     private /* final */ AtmosphereFramework framework;

--- a/modules/cpr/src/main/java/org/atmosphere/websocket/protocol/SimpleHttpProtocol.java
+++ b/modules/cpr/src/main/java/org/atmosphere/websocket/protocol/SimpleHttpProtocol.java
@@ -47,7 +47,7 @@ import static org.atmosphere.websocket.protocol.ProtocolUtil.constructRequest;
  */
 public class SimpleHttpProtocol implements WebSocketProtocol, Serializable {
 
-	private static final long serialVersionUID = 7526472295622776111L;
+    private static final long serialVersionUID = 7526472295622776111L;
     private static final Logger logger = LoggerFactory.getLogger(SimpleHttpProtocol.class);
     protected final static String TEXT = "text/plain";
     protected String contentType = TEXT;

--- a/modules/cpr/src/main/java/org/atmosphere/websocket/protocol/SimpleHttpProtocol.java
+++ b/modules/cpr/src/main/java/org/atmosphere/websocket/protocol/SimpleHttpProtocol.java
@@ -47,6 +47,7 @@ import static org.atmosphere.websocket.protocol.ProtocolUtil.constructRequest;
  */
 public class SimpleHttpProtocol implements WebSocketProtocol, Serializable {
 
+	private static final long serialVersionUID = 7526472295622776111L;
     private static final Logger logger = LoggerFactory.getLogger(SimpleHttpProtocol.class);
     protected final static String TEXT = "text/plain";
     protected String contentType = TEXT;

--- a/modules/native/src/main/java/org/atmosphere/cpr/AtmosphereServlet.java
+++ b/modules/native/src/main/java/org/atmosphere/cpr/AtmosphereServlet.java
@@ -44,7 +44,7 @@ import static org.atmosphere.cpr.HeaderConfig.WEBSOCKET_UPGRADE;
  */
 public class AtmosphereServlet extends HttpServlet implements CometProcessor, HttpEventServlet, org.apache.catalina.comet.CometProcessor {
 
-	private static final long serialVersionUID = 7526472295622776147L;
+    private static final long serialVersionUID = 7526472295622776147L;
     protected static final Logger logger = LoggerFactory.getLogger(AtmosphereServlet.class);
     protected final AtmosphereFrameworkInitializer initializer;
 

--- a/modules/native/src/main/java/org/atmosphere/cpr/AtmosphereServlet.java
+++ b/modules/native/src/main/java/org/atmosphere/cpr/AtmosphereServlet.java
@@ -44,6 +44,7 @@ import static org.atmosphere.cpr.HeaderConfig.WEBSOCKET_UPGRADE;
  */
 public class AtmosphereServlet extends HttpServlet implements CometProcessor, HttpEventServlet, org.apache.catalina.comet.CometProcessor {
 
+	private static final long serialVersionUID = 7526472295622776147L;
     protected static final Logger logger = LoggerFactory.getLogger(AtmosphereServlet.class);
     protected final AtmosphereFrameworkInitializer initializer;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2057 - “Serializable classes should have a version id”. You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2057

Please let me know if you have any questions.

Ahmed