### PR TITLE
Fix spring load order.

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -560,6 +560,8 @@ public class AtmosphereFramework {
         this.isFilter = isFilter;
         this.autoDetectHandlers = autoDetectHandlers;
         config = newAtmosphereConfig();
+        populateBroadcasterType();
+        populateObjectFactoryType();
     }
 
     /**
@@ -865,8 +867,6 @@ public class AtmosphereFramework {
 
         servletConfig(sc, wrap);
         readSystemProperties();
-        populateBroadcasterType();
-        populateObjectFactoryType();
         loadMetaService();
         onPreInit();
 


### PR DESCRIPTION
In spring, the spring beans are wired before the servlet init/framework.init method
is called.

Eg the following code doesn't get the right broadcasterFactory cos it
didn't call the framework init method yet.
```java
@Bean
public BroadcasterFactory broadcasterFactory() throws ServletException, InstantiationException, IllegalAccessException {
return atmosphereFramework().getAtmosphereConfig().getBroadcasterFactory();
}
```