### PR TITLE
Can we pass copySession parameter as true

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/Jetty9WebSocketHandler.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/Jetty9WebSocketHandler.java
@@ -101,7 +101,7 @@ public class Jetty9WebSocketHandler implements WebSocketListener {
             HttpServletRequest r = originalRequest(session);
             if (r != null) {
                 // We close except the session which we can still reach.
-                request = AtmosphereRequest.cloneRequest(r, true, false, false, framework.getAtmosphereConfig().getInitParameter(PROPERTY_SESSION_CREATE, true));
+                request = AtmosphereRequest.cloneRequest(r, true, true, false, framework.getAtmosphereConfig().getInitParameter(PROPERTY_SESSION_CREATE, true));
             } else {
                 // Bad Bad Bad
                 request = AtmosphereRequest.cloneRequest(r, true, true, false, framework.getAtmosphereConfig().getInitParameter(PROPERTY_SESSION_CREATE, true));


### PR DESCRIPTION
Passing copySession parameter as true to get the http session.  

if (r != null) {
                // We close except the session which we can still reach.
                request = AtmosphereRequest.cloneRequest(r, true, true, false, framework.getAtmosphereConfig().getInitParameter(PROPERTY_SESSION_CREATE, true));
            }