### PR TITLE
Fix ConcurrentModificationException.

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/websocket/WebSocket.java
+++ b/modules/cpr/src/main/java/org/atmosphere/websocket/WebSocket.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.atmosphere.cpr.HeaderConfig.X_ATMOSPHERE_ERROR;
@@ -121,9 +122,10 @@ public abstract class WebSocket extends AtmosphereInterceptorWriter implements K
      *
      * @return this.
      */
-    public WebSocket shiftAttributes() {
-        attributesAtWebSocketOpen = AtmosphereResourceImpl.class.cast(r).getRequest(false).localAttributes().unmodifiableMap();
-        return this;
+    public synchronized WebSocket shiftAttributes() {
+    	attributesAtWebSocketOpen = new ConcurrentHashMap<String, Object>();
+    	attributesAtWebSocketOpen.putAll(AtmosphereResourceImpl.class.cast(r).getRequest(false).localAttributes().unmodifiableMap());
+    	return this;
     }
 
     /**

--- a/modules/cpr/src/main/java/org/atmosphere/websocket/WebSocket.java
+++ b/modules/cpr/src/main/java/org/atmosphere/websocket/WebSocket.java
@@ -123,9 +123,9 @@ public abstract class WebSocket extends AtmosphereInterceptorWriter implements K
      * @return this.
      */
     public synchronized WebSocket shiftAttributes() {
-    	attributesAtWebSocketOpen = new ConcurrentHashMap<String, Object>();
-    	attributesAtWebSocketOpen.putAll(AtmosphereResourceImpl.class.cast(r).getRequest(false).localAttributes().unmodifiableMap());
-    	return this;
+        attributesAtWebSocketOpen = new ConcurrentHashMap<String, Object>();
+        attributesAtWebSocketOpen.putAll(AtmosphereResourceImpl.class.cast(r).getRequest(false).localAttributes().unmodifiableMap());
+        return this;
     }
 
     /**

--- a/modules/cpr/src/main/java/org/atmosphere/websocket/protocol/ProtocolUtil.java
+++ b/modules/cpr/src/main/java/org/atmosphere/websocket/protocol/ProtocolUtil.java
@@ -23,6 +23,9 @@ import org.atmosphere.websocket.WebSocket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class ProtocolUtil {
     private final static Logger logger = LoggerFactory.getLogger(ProtocolUtil.class);
 
@@ -35,14 +38,14 @@ public class ProtocolUtil {
 
         AtmosphereResource resource = webSocket.resource();
         AtmosphereRequest request = AtmosphereResourceImpl.class.cast(resource).getRequest(false);
-        
+        Map<String, Object> m = attributes(webSocket, request);
 
         // We need to create a new AtmosphereRequest as WebSocket message may arrive concurrently on the same connection.
         AtmosphereRequestImpl.Builder b = (new AtmosphereRequestImpl.Builder()
                 .request(request)
                 .method(methodType)
                 .contentType(contentType == null ? request.getContentType() : contentType)
-                .attributes(webSocket.attributes())
+                .attributes(m)
                 .pathInfo(pathInfo)
                 .contextPath(request.getContextPath())
                 .servletPath(request.getServletPath())
@@ -52,5 +55,11 @@ public class ProtocolUtil {
                 .headers(request.headersMap())
                 .session(resource.session()));
         return b;
+    }
+
+    private static Map<String, Object> attributes(WebSocket webSocket, AtmosphereRequest request) {
+        Map<String, Object> m = new ConcurrentHashMap<String, Object>();
+        m.putAll(webSocket.attributes());
+        return m;
     }
 }

--- a/modules/cpr/src/main/java/org/atmosphere/websocket/protocol/ProtocolUtil.java
+++ b/modules/cpr/src/main/java/org/atmosphere/websocket/protocol/ProtocolUtil.java
@@ -23,9 +23,6 @@ import org.atmosphere.websocket.WebSocket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 public class ProtocolUtil {
     private final static Logger logger = LoggerFactory.getLogger(ProtocolUtil.class);
 
@@ -38,14 +35,14 @@ public class ProtocolUtil {
 
         AtmosphereResource resource = webSocket.resource();
         AtmosphereRequest request = AtmosphereResourceImpl.class.cast(resource).getRequest(false);
-        Map<String, Object> m = attributes(webSocket, request);
+        
 
         // We need to create a new AtmosphereRequest as WebSocket message may arrive concurrently on the same connection.
         AtmosphereRequestImpl.Builder b = (new AtmosphereRequestImpl.Builder()
                 .request(request)
                 .method(methodType)
                 .contentType(contentType == null ? request.getContentType() : contentType)
-                .attributes(m)
+                .attributes(webSocket.attributes())
                 .pathInfo(pathInfo)
                 .contextPath(request.getContextPath())
                 .servletPath(request.getServletPath())
@@ -55,11 +52,5 @@ public class ProtocolUtil {
                 .headers(request.headersMap())
                 .session(resource.session()));
         return b;
-    }
-
-    private static Map<String, Object> attributes(WebSocket webSocket, AtmosphereRequest request) {
-        Map<String, Object> m = new ConcurrentHashMap<String, Object>();
-        m.putAll(webSocket.attributes());
-        return m;
     }
 }


### PR DESCRIPTION
This fixes a ConcurrentModificationException when a request websocket frame comes in and a websocket response is in process at the same time. I have created a test in the Nettosphere project that replicates the issue. It shows thats Atmosphere fails before this PR, and it is successful with this PR.