### PR TITLE
Evaluation of servlet property ApplicationConfig.AUTODETECT_BROADCAST

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -1653,7 +1653,7 @@ public class AtmosphereFramework {
     protected String lookupDefaultBroadcasterType(String defaultB) {
 
         String drop = servletConfig != null ? servletConfig.getInitParameter(ApplicationConfig.AUTODETECT_BROADCASTER) : null;
-        if (drop == null || !Boolean.parseBoolean(drop)) {
+        if (drop == null || Boolean.parseBoolean(drop)) {
             for (String b : broadcasterTypes) {
                 try {
                     Class.forName(b);


### PR DESCRIPTION
AtmosphereFramework is using the property ApplicationConfig.AUTODETECT_BROADCAST to evaluate if some other Broadcaster as DefaultBroadcaster should be used and if this Broadcaster should be detected automatically on the classpath. I would expect that switiching off this behaviour requires to set

ApplicationConfig.AUTODETECT_BROADCAST = false

However, at the moment auto-detection is switched off by setting

ApplicationConfig.AUTODETECT_BROADCAST = true.

This merge request will fix that behaviour.