### PR TITLE
Fix for issue #2141

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
@@ -963,13 +963,5 @@ public interface ApplicationConfig {
      * Value: org.atmosphere.inject.InjectableObjectFactory.listeners
      */
     String INJECTION_LISTENERS = "org.atmosphere.inject.InjectableObjectFactory.listeners";
-
-    /**
-     * Always propagates the content-type of the original message to a dispathed AtmosphereRequest.
-     * <p/>
-     * Default: null <br>
-     * Vlaue: org.atmosphere.cpr.forceContentType
-     */
-    String FORCE_CONTENT_TYPE = "org.atmosphere.cpr.forceContentType";
 }
 

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequestImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequestImpl.java
@@ -1399,9 +1399,23 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
             s = e.nextElement();
             b.localAttributes.put(s, attributeWithoutException(request, s));
         }
-        return b.request(request).build();
+        return b.request(request).body(getRequestBody(request)).build();
     }
 
+    private static String getRequestBody(final HttpServletRequest request) {
+        String requestBody = null;
+        if (request != null) {
+            try {
+                requestBody = request
+                        .getReader()
+                        .lines()
+                        .reduce("", (result, line) -> result + line);
+            } catch (IOException ex) {
+                logger.warn("Unexpected getRequestBody exception", ex);
+            }
+        }
+        return requestBody;
+    }
 
     /**
      * Copy the HttpServletRequest content inside an AtmosphereRequest. By default the returned AtmosphereRequest

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequestImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequestImpl.java
@@ -210,14 +210,7 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
 
     @Override
     public String getContentType() {
-        return b.contentType != null ? b.contentType
-                : (b.body.isEmpty() && b.reader == null && b.inputStream == null && !isForceContentType())
-                ? null : b.request.getContentType();
-    }
-
-    private boolean isForceContentType() {
-        return resource() != null && Boolean.parseBoolean(resource().getAtmosphereConfig()
-                .getInitParameter(ApplicationConfig.FORCE_CONTENT_TYPE));
+        return b.contentType != null ? b.contentType : (b.body.isEmpty() && b.reader == null && b.inputStream == null) ? null : b.request.getContentType();
     }
 
     @Override

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereRequestTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereRequestTest.java
@@ -17,7 +17,6 @@ package org.atmosphere.cpr;
 
 import org.atmosphere.container.BlockingIOCometSupport;
 import org.atmosphere.handler.AbstractReflectorAtmosphereHandler;
-import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -32,11 +31,9 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class AtmosphereRequestTest {
@@ -319,28 +316,5 @@ public class AtmosphereRequestTest {
         assertFalse(e.get().hasString());
         assertEquals(new String(e.get().asBytes()), "test");
 
-    }
-
-    @Test
-    public void testForceContentType() throws Exception {
-        // a non-empty content
-        AtmosphereRequest request = new AtmosphereRequestImpl.Builder().pathInfo("/a").body("test".getBytes()).build();
-        // default type for a non-empty type
-        assertEquals(request.getContentType(), "text/plain");
-
-
-        // no content
-        request = new AtmosphereRequestImpl.Builder().pathInfo("/a").build();
-        // no content-type by default
-        assertNull(request.getContentType());
-
-        // no content
-        AtmosphereResource resource = Mockito.mock(AtmosphereResource.class);
-        AtmosphereConfig config = Mockito.mock(AtmosphereConfig.class);
-        when(config.getInitParameter(ApplicationConfig.FORCE_CONTENT_TYPE)).thenReturn("true");
-        when(resource.getAtmosphereConfig()).thenReturn(config);
-        request.setAttribute(FrameworkConfig.ATMOSPHERE_RESOURCE, resource);
-        // force_content_type is enabled
-        assertEquals(request.getContentType(), "text/plain");
     }
 }


### PR DESCRIPTION
The AtmosphereRequestImpl has been created with a NULL_OBJETC instance as part of the AtmosphereRequestImpl.Builder body. That being said, I created a fix to set the actual request body as part of the builder right before creating a AtmosphereRequestImpl.
