### PR TITLE
Issue #2063: duplicate messages will be overriden with the help of

### DIFF
--- a/modules/cpr/src/test/java/org/atmosphere/cpr/UUIDBroadcasterCacheTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/UUIDBroadcasterCacheTest.java
@@ -76,7 +76,7 @@ public class UUIDBroadcasterCacheTest {
         broadcaster.broadcast("e2").get();
         broadcaster.broadcast("e3").get();
 
-        assertEquals(broadcasterCache.messages().get(ar.uuid()).getQueue().size(), 2);
+        assertEquals(broadcasterCache.messages().get(ar.uuid()).size(), 2);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class UUIDBroadcasterCacheTest {
         broadcaster.broadcast("e3").get();
 
         assertEquals(broadcasterCache.messages().size(), 1);
-        assertEquals(broadcasterCache.messages().get(ar.uuid()).getQueue().size(), 1);
+        assertEquals(broadcasterCache.messages().get(ar.uuid()).size(), 1);
     }
 
     @Test
@@ -137,7 +137,7 @@ public class UUIDBroadcasterCacheTest {
 
         latch.await(10, TimeUnit.SECONDS);
 
-        assertEquals(broadcasterCache.messages().get(ar.uuid()).getQueue().size(), 100);
+        assertEquals(broadcasterCache.messages().get(ar.uuid()).size(), 100);
     }
 
     public final static class AR implements AtmosphereHandler {


### PR DESCRIPTION
Using concurrentLinkedQueue rather than ClientQueue to fix long-polling missing messages