### PR TITLE
More compact JSON data for JSONP transport, save 2 bytes for every response

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/interceptor/JSONPAtmosphereInterceptor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/interceptor/JSONPAtmosphereInterceptor.java
@@ -41,7 +41,7 @@ public class JSONPAtmosphereInterceptor extends AtmosphereInterceptorAdapter {
 
     private static final Logger logger = LoggerFactory.getLogger(JSONPAtmosphereInterceptor.class);
     private String endChunk = "\"});";
-    private String startChunk = "({\"message\" : \"";
+    private String startChunk = "({\"message\":\"";
     private AtmosphereConfig config;
 
     @Override


### PR DESCRIPTION
Can't see why this wouldn't be safe to optimize :)
