### PR TITLE
This fixes a possible memory leak when thread pools are shared , fixe…

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -1807,9 +1807,6 @@ public class AtmosphereFramework {
         closeAtmosphereResource();
         destroyInterceptors();
 
-        // Invoke ShutdownHook.
-        config.destroy();
-
         BroadcasterFactory factory = broadcasterFactory;
         if (factory != null) {
             factory.destroy();
@@ -1832,6 +1829,9 @@ public class AtmosphereFramework {
         WebSocketProcessorFactory.getDefault().destroy();
 
         ExecutorsFactory.reset(config);
+        
+        // Invoke ShutdownHook.
+        config.destroy();
 
         resetStates();
 


### PR DESCRIPTION
…d tab character closes #2223

This commit might fix a probable memory leak that can happen in very rare cases when thread pools are configured to work with shared.

27-Oct-2016 06:43:50.263 WARNING [localhost-startStop-2] org.apache.catalina.loader.WebappClassLoaderBase.clearReferencesThreads The web application [prweb] appears to have started a thread named [Atmosphere-Scheduler-29341] but has failed to stop it. This is very likely to create a memory leak.