### PR TITLE
Fix for #2234 and #2236: RPC payload leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ samples/gwt-demo/src/main/webapp/WEB-INF/classes/
 samples/gwt-chat/src/main/webapp/WEB-INF/classes/
 samples/gwt-conn-share/src/main/webapp/WEB-INF/classes/
 atlassian-ide-plugin.xml
+/bin/

--- a/modules/cpr/src/main/java/org/atmosphere/cache/DefaultBroadcasterCache.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cache/DefaultBroadcasterCache.java
@@ -19,6 +19,7 @@ import org.atmosphere.cpr.AtmosphereConfig;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.BroadcasterCache;
 import org.atmosphere.cpr.BroadcasterCacheListener;
+import org.atmosphere.cpr.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,5 +84,14 @@ public class DefaultBroadcasterCache implements BroadcasterCache {
 
     @Override
     public void configure(AtmosphereConfig config) {
+    }
+
+    @Override
+    public Serializer getCacheSerializer() {
+        return null;
+    }
+    
+    @Override
+    public void setCacheSerializer(Serializer serializer) {
     }
 }

--- a/modules/cpr/src/main/java/org/atmosphere/cache/SessionBroadcasterCache.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cache/SessionBroadcasterCache.java
@@ -17,6 +17,7 @@
 package org.atmosphere.cache;
 
 import org.atmosphere.cpr.AtmosphereResource;
+import org.atmosphere.cpr.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,5 +95,14 @@ public class SessionBroadcasterCache extends AbstractBroadcasterCache {
             logger.warn("The Session has been invalidated. Unable to retrieve cached messages");
             return Collections.emptyList();
         }
+    }
+
+    @Override
+    public Serializer getCacheSerializer() {
+        return null;
+    }
+    
+    @Override
+    public void setCacheSerializer(Serializer serializer) {
     }
 }

--- a/modules/cpr/src/main/java/org/atmosphere/cache/UUIDBroadcasterCache.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cache/UUIDBroadcasterCache.java
@@ -35,6 +35,7 @@ import org.atmosphere.cpr.AtmosphereConfig;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.BroadcasterCache;
 import org.atmosphere.cpr.BroadcasterCacheListener;
+import org.atmosphere.cpr.Serializer;
 import org.atmosphere.util.ExecutorsFactory;
 import org.atmosphere.util.UUIDProvider;
 import org.slf4j.Logger;
@@ -61,6 +62,7 @@ public class UUIDBroadcasterCache implements BroadcasterCache {
     private boolean shared = true;
     protected final List<BroadcasterCacheListener> listeners = new LinkedList<BroadcasterCacheListener>();
     private UUIDProvider uuidProvider;
+    private Serializer serializer = null;
 
     @Override
     public void configure(AtmosphereConfig config) {
@@ -327,7 +329,17 @@ public class UUIDBroadcasterCache implements BroadcasterCache {
         activeClients.put(uuid, now);
         return this;
     }
-
+    
+    @Override
+    public Serializer getCacheSerializer() {
+        return serializer;
+    }
+    
+    @Override
+    public void setCacheSerializer(Serializer serializer) {
+        this.serializer = serializer;
+    }
+    
     @Override
     public String toString() {
         return this.getClass().getName();

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterCache.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterCache.java
@@ -84,6 +84,18 @@ public interface BroadcasterCache extends AtmosphereConfigAware {
      * and some future must be cancelled. This method will always be invoked when a {@link Broadcaster} gets destroyed.
      */
     void cleanup();
+    
+    /**
+     * Get serializer for cache messages.
+     * @return The {@link Serializer}.
+     */
+    Serializer getCacheSerializer();
+    
+    /**
+     * Set serializer for cache messages.
+     * @param serializer {@link Serializer}.
+     */
+    void setCacheSerializer(Serializer serializer);
 
     /**
      * Start tracking messages associated with {@link AtmosphereResource} from the cache.

--- a/modules/cpr/src/main/java/org/atmosphere/handler/AbstractReflectorAtmosphereHandler.java
+++ b/modules/cpr/src/main/java/org/atmosphere/handler/AbstractReflectorAtmosphereHandler.java
@@ -17,6 +17,7 @@
 
 package org.atmosphere.handler;
 
+import org.atmosphere.cache.CacheMessage;
 import org.atmosphere.cpr.ApplicationConfig;
 import org.atmosphere.cpr.AtmosphereConfig;
 import org.atmosphere.cpr.AtmosphereHandler;
@@ -86,9 +87,13 @@ public abstract class AbstractReflectorAtmosphereHandler implements AtmosphereSe
 
                 if (message instanceof List) {
                     for (Object s : (List<Object>) message) {
+                        if (s instanceof CacheMessage)
+                            s = ((CacheMessage) s).getMessage();
                         resource.getSerializer().write(resource.getResponse().getOutputStream(), s);
                     }
                 } else {
+                    if (message instanceof CacheMessage)
+                        message = ((CacheMessage) message).getMessage();
                     resource.getSerializer().write(resource.getResponse().getOutputStream(), message);
                 }
             } catch (Throwable ex) {

--- a/modules/cpr/src/main/java/org/atmosphere/interceptor/AtmosphereResourceStateRecovery.java
+++ b/modules/cpr/src/main/java/org/atmosphere/interceptor/AtmosphereResourceStateRecovery.java
@@ -286,6 +286,9 @@ public class AtmosphereResourceStateRecovery implements AtmosphereInterceptor {
                 // We cannot add the resource now. we need to first make sure there is no cached message.
                 cache = b.getBroadcasterConfig().getBroadcasterCache();
                 List<Object> t = cache.retrieveFromCache(b.getID(), r.uuid());
+                
+                if (cache.getCacheSerializer() != null)
+                    r.setSerializer(cache.getCacheSerializer());
 
                 t = b.getBroadcasterConfig().applyFilters(r, t);
                 if (!t.isEmpty()) {


### PR DESCRIPTION
Cached messages are now propery written to output stream instead of being
stringified.