### PR TITLE
Update JSR356Endpoint.java

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
@@ -302,7 +302,7 @@ public class JSR356Endpoint extends Endpoint {
     @Override
     public void onError(javax.websocket.Session session, java.lang.Throwable t) {
         try {
-            //logger.error("", t);
+            logger.debug("", t);
             webSocketProcessor.notifyListener(webSocket,
                     new WebSocketEventListener.WebSocketEvent<Throwable>(t, WebSocketEventListener.WebSocketEvent.TYPE.EXCEPTION, webSocket));
         } catch (Exception ex) {

--- a/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
@@ -302,7 +302,7 @@ public class JSR356Endpoint extends Endpoint {
     @Override
     public void onError(javax.websocket.Session session, java.lang.Throwable t) {
         try {
-            logger.error("", t);
+            //logger.error("", t);
             webSocketProcessor.notifyListener(webSocket,
                     new WebSocketEventListener.WebSocketEvent<Throwable>(t, WebSocketEventListener.WebSocketEvent.TYPE.EXCEPTION, webSocket));
         } catch (Exception ex) {


### PR DESCRIPTION
Kill this log output please!! We use Tomcat, but every time the web page reloaded, tomcat will call JSR356Endpoint#onError(), but before you call callbackList, you just output the error. Our log files are FULL OF WEBSOCKET ERROR!