### PR TITLE
Throw exception if Universe methods are used when they are not reliable

### DIFF
--- a/modules/runtime/src/main/java/org/atmosphere/runtime/Universe.java
+++ b/modules/runtime/src/main/java/org/atmosphere/runtime/Universe.java
@@ -15,14 +15,12 @@
 */
 package org.atmosphere.runtime;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Universe contains static reference to Atmosphere's Factories.
  * </p>
- * PLEASE DO NOT USE THIS CLASS IF YOUR APPLICATION CONTAINS WEBFRAGMENTS OR MORE THAN ONCE ATMOSPHERE SERVLET DEFINED
- * AS THIS CLASS IS USING STATIC INSTANCE.
+ * PLEASE DO NOT USE THIS CLASS IF YOUR APPLICATION CONTAINS WEBFRAGMENTS OR
+ * MORE THAN ONCE ATMOSPHERE SERVLET DEFINED AS THIS CLASS IS USING STATIC
+ * INSTANCE.
  * </p>
  * <p/>
  * This is ugly, only here to save your buts, Atmosphere users!
@@ -31,21 +29,26 @@ import org.slf4j.LoggerFactory;
  */
 public class Universe {
 
-    private static final Logger logger = LoggerFactory.getLogger(Universe.class);
     private static BroadcasterFactory factory;
+    private static boolean factoryDuplicate = false;
     private static AtmosphereFramework framework;
+    private static boolean frameworkDuplicate = false;
     private static AtmosphereResourceFactory resourceFactory;
+    private static boolean resourceFactoryDuplicate = false;
     private static AtmosphereResourceSessionFactory sessionFactory;
+    private static boolean sessionFactoryDuplicate = false;
     private static DefaultMetaBroadcaster metaBroadcaster;
+    private static boolean metaBroadcasterDuplicate = false;
 
     /**
      * Set the must be unique {@link DefaultMetaBroadcaster}
      *
-     * @param a {@link DefaultMetaBroadcaster}
+     * @param a
+     *            {@link DefaultMetaBroadcaster}
      */
     public static void metaBroadcaster(DefaultMetaBroadcaster a) {
         if (metaBroadcaster != null) {
-            logger.warn("More than one Universe configured. Universe class will gives wrong object reference {}", a);
+            metaBroadcasterDuplicate = true;
         }
         metaBroadcaster = a;
     }
@@ -53,11 +56,12 @@ public class Universe {
     /**
      * Set the must be unique {@link org.atmosphere.runtime.BroadcasterFactory}
      *
-     * @param a {@link org.atmosphere.runtime.BroadcasterFactory}
+     * @param a
+     *            {@link org.atmosphere.runtime.BroadcasterFactory}
      */
     public static void broadcasterFactory(BroadcasterFactory a) {
         if (factory != null) {
-            logger.warn("More than one Universe configured. Universe class will gives wrong object reference {}", a);
+            factoryDuplicate = true;
         }
         factory = a;
     }
@@ -65,11 +69,12 @@ public class Universe {
     /**
      * Set the must be unique {@link org.atmosphere.runtime.AtmosphereFramework}
      *
-     * @param a {@link org.atmosphere.runtime.AtmosphereFramework}
+     * @param a
+     *            {@link org.atmosphere.runtime.AtmosphereFramework}
      */
     public static void framework(AtmosphereFramework a) {
         if (framework != null) {
-            logger.warn("More than one Universe configured. Universe class will gives wrong object reference {}", a);
+            frameworkDuplicate = true;
         }
         framework = a;
     }
@@ -77,23 +82,27 @@ public class Universe {
     /**
      * Set the must be unique {@link AtmosphereResourceFactory}
      *
-     * @param a {@link AtmosphereResourceFactory}
+     * @param a
+     *            {@link AtmosphereResourceFactory}
      */
     public static void resourceFactory(AtmosphereResourceFactory a) {
         if (resourceFactory != null) {
-            logger.warn("More than one Universe configured. Universe class will gives wrong object reference {}", a);
+            resourceFactoryDuplicate = true;
         }
         resourceFactory = a;
     }
 
     /**
-     * Set the must be unique {@link org.atmosphere.runtime.AtmosphereResourceSessionFactory}
+     * Set the must be unique
+     * {@link org.atmosphere.runtime.AtmosphereResourceSessionFactory}
      *
-     * @param a {@link org.atmosphere.runtime.AtmosphereResourceSessionFactory}
+     * @param a
+     *            {@link org.atmosphere.runtime.AtmosphereResourceSessionFactory}
      */
-    public static void sessionResourceFactory(AtmosphereResourceSessionFactory a) {
+    public static void sessionResourceFactory(
+            AtmosphereResourceSessionFactory a) {
         if (sessionFactory != null) {
-            logger.warn("More than one Universe configured. Universe class will gives wrong object reference {}", a);
+            sessionFactoryDuplicate = true;
         }
         sessionFactory = a;
     }
@@ -104,6 +113,10 @@ public class Universe {
      * @return the {@link org.atmosphere.runtime.BroadcasterFactory}
      */
     public static BroadcasterFactory broadcasterFactory() {
+        if (factoryDuplicate) {
+            throw new IllegalStateException(
+                    "More than one instance has been stored. Universe cannot be used.");
+        }
         return factory;
     }
 
@@ -113,6 +126,10 @@ public class Universe {
      * @return the {@link org.atmosphere.runtime.AtmosphereFramework}
      */
     public static AtmosphereFramework framework() {
+        if (frameworkDuplicate) {
+            throw new IllegalStateException(
+                    "More than one instance has been stored. Universe cannot be used.");
+        }
         return framework;
     }
 
@@ -122,15 +139,25 @@ public class Universe {
      * @return the {@link AtmosphereResourceFactory}
      */
     public static AtmosphereResourceFactory resourceFactory() {
+        if (resourceFactoryDuplicate) {
+            throw new IllegalStateException(
+                    "More than one instance has been stored. Universe cannot be used.");
+        }
         return resourceFactory;
     }
 
     /**
-     * Return the {@link org.atmosphere.runtime.AtmosphereResourceSessionFactory}
+     * Return the
+     * {@link org.atmosphere.runtime.AtmosphereResourceSessionFactory}
      *
-     * @return the {@link org.atmosphere.runtime.AtmosphereResourceSessionFactory}
+     * @return the
+     *         {@link org.atmosphere.runtime.AtmosphereResourceSessionFactory}
      */
     public static AtmosphereResourceSessionFactory sessionFactory() {
+        if (sessionFactoryDuplicate) {
+            throw new IllegalStateException(
+                    "More than one instance has been stored. Universe cannot be used.");
+        }
         return sessionFactory;
     }
 
@@ -140,6 +167,10 @@ public class Universe {
      * @return the {@link DefaultMetaBroadcaster}
      */
     public static DefaultMetaBroadcaster metaBroadcaster() {
+        if (metaBroadcasterDuplicate) {
+            throw new IllegalStateException(
+                    "More than one instance has been stored. Universe cannot be used.");
+        }
         return metaBroadcaster;
     }
 }


### PR DESCRIPTION
The previous version causes a lot of logging about Universe not being reliable
even though you never use Universe. This changes the behavior so that you will
instead get an exception only when actually using the methods, when they will not
work properly.