### PR TITLE
Remove the broadcaster's wrapper as part of destroying the broadcaster

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
@@ -206,6 +206,8 @@ public class DefaultBroadcaster implements Broadcaster {
                 if (!sharedListeners) {
                     broadcasterListeners.clear();
                 }
+
+                config.framework().removeAtmosphereHandler(name);
             }
 
             resources.clear();


### PR DESCRIPTION
After pulling down 2.4.14 in response to https://github.com/Atmosphere/atmosphere/issues/2186#issuecomment-320466366, I found that DefaultBroadcaster and Wrapper objects were still leaking consistently (although other stuff had been addressed). This PR gave me the effect I was looking for although I'm unsure of whether it might have other unintended side effects.