### PR TITLE
Headers handling should not replace null with empty string

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResponseImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResponseImpl.java
@@ -344,10 +344,8 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public void setHeader(String name, String value) {
-        //https://github.com/Atmosphere/atmosphere/issues/1783
-        if (value == null) value = "";
-
-        headers.put(name, value);
+        if (value == null) headers.remove(name);
+        else headers.put(name, value);
 
         if (delegateToNativeResponse) {
             _r().setHeader(name, value);
@@ -360,9 +358,6 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public void addHeader(String name, String value) {
-        //https://github.com/Atmosphere/atmosphere/issues/1783
-        if (value == null) value = "";
-
         headers.put(name, value);
 
         if (delegateToNativeResponse) {


### PR DESCRIPTION
Fixes problem described here: https://github.com/Atmosphere/atmosphere/issues/1783#issuecomment-339526412 

As you can see in Jetty sources (https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/jetty-websocket/websocket-servlet/src/main/java/org/eclipse/jetty/websocket/servlet/ServletUpgradeResponse.java#L74), it uses `setHeader` with `null` value to remove header. JavaDoc doesn't mention `null` values, but I don't think that it's a good idea to replace `null` with empty string. 