### PR TITLE
Do not close a reconnected websocket

### DIFF
--- a/modules/runtime/src/main/java/org/atmosphere/websocket/DefaultWebSocketProcessor.java
+++ b/modules/runtime/src/main/java/org/atmosphere/websocket/DefaultWebSocketProcessor.java
@@ -643,8 +643,11 @@ public class DefaultWebSocketProcessor implements WebSocketProcessor, Serializab
                             ExecutorsFactory.getScheduler(framework.getAtmosphereConfig()).schedule(new Callable<Object>() {
                                 @Override
                                 public Object call() throws Exception {
-                                    executeClose(webSocket, 1005);
-                                    finish(webSocket, resource, r, s, !allowedToClose);
+                                    if (resource.isSuspended()) {
+                                        // Do not close if the resource has reconnected already
+                                        executeClose(webSocket, 1005);
+                                        finish(webSocket, resource, r, s, !allowedToClose);
+                                    }
                                     return null;
                                 }
                             }, ff ? (closingTime == 0 ? 1000 : closingTime) : closingTime, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
If you click on a download link in Firefox, then the websocket is disconnected briefly until Firefox realizes it is a download request. The reconnect then happens in less than 1 second so the new connection will be closed on the server after the timeout of 1s has elapsed (when the code tries to close an old connection). After this the websocket connection will not work.