### PR TITLE
github-issue-#2322: AtmosphereResponseImpl#getHeaders should return `…

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResponseImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResponseImpl.java
@@ -454,7 +454,9 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
         } else {
             h = headers.get(name);
         }
-        s.add(h);
+        if(h != null) {
+            s.add(h);
+        }
 
         if (servlet30) {
             Collection<String> r = _r().getHeaders(name);
@@ -463,7 +465,10 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
             }
         }
 
-        return Collections.unmodifiableList(s);
+        if(!s.isEmpty()) {
+            return Collections.unmodifiableList(s);
+        }
+        return null;
     }
 
     @Override

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResponseImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResponseImpl.java
@@ -454,7 +454,8 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
         } else {
             h = headers.get(name);
         }
-        if(h != null) {
+
+        if(headers.containsKey(name)) {
             s.add(h);
         }
 

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereResponseImplTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereResponseImplTest.java
@@ -1,0 +1,75 @@
+package org.atmosphere.cpr;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class AtmosphereResponseImplTest {
+
+    private AtmosphereFramework framework;
+    private AtmosphereConfig config;
+    private AsynchronousProcessor processor;
+    private final AtmosphereHandler handler = mock(AtmosphereHandler.class);
+
+    @BeforeMethod
+    public void create() throws Throwable {
+        framework = new AtmosphereFramework();
+        framework.setAsyncSupport(mock(AsyncSupport.class));
+        framework.init(new ServletConfig() {
+            @Override
+            public String getServletName() {
+                return "void";
+            }
+
+            @Override
+            public ServletContext getServletContext() {
+                return mock(ServletContext.class);
+            }
+
+            @Override
+            public String getInitParameter(String name) {
+                return null;
+            }
+
+            @Override
+            public Enumeration<String> getInitParameterNames() {
+                return null;
+            }
+        });
+        config = framework.getAtmosphereConfig();
+        processor = new AsynchronousProcessor(config) {
+            @Override
+            public Action service(AtmosphereRequest req, AtmosphereResponse res) throws IOException, ServletException {
+                return action(req, res);
+            }
+        };
+    }
+
+    @Test
+    public void headerTest() {
+        framework.addAtmosphereHandler("/*", handler);
+        AtmosphereResponse response = new AtmosphereResponseImpl.Builder().header("header 1", "header 1 value").build();
+        assertEquals(response.getHeaders("header 1"), Collections.singleton("header 1 value"));
+    }
+
+    @Test
+    public void headerTest2() {
+        framework.addAtmosphereHandler("/*", handler);
+        AtmosphereResponse response = new AtmosphereResponseImpl.Builder()
+                .header("header 1", "header 1 value")
+                .header("header 2", "header 2 value")
+                .header("header 3", null)
+                .build();
+        assertEquals(response.getHeaders("header 1"), Collections.singleton("header 1 value"));
+    }
+}

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereResponseImplTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereResponseImplTest.java
@@ -17,8 +17,7 @@ import org.testng.annotations.Test;
 public class AtmosphereResponseImplTest {
 
     private AtmosphereFramework framework;
-    private AtmosphereConfig config;
-    private AsynchronousProcessor processor;
+
     private final AtmosphereHandler handler = mock(AtmosphereHandler.class);
 
     @BeforeMethod
@@ -46,30 +45,36 @@ public class AtmosphereResponseImplTest {
                 return null;
             }
         });
-        config = framework.getAtmosphereConfig();
-        processor = new AsynchronousProcessor(config) {
-            @Override
-            public Action service(AtmosphereRequest req, AtmosphereResponse res) throws IOException, ServletException {
-                return action(req, res);
-            }
-        };
     }
 
     @Test
-    public void headerTest() {
-        framework.addAtmosphereHandler("/*", handler);
-        AtmosphereResponse response = new AtmosphereResponseImpl.Builder().header("header 1", "header 1 value").build();
-        assertEquals(response.getHeaders("header 1"), Collections.singleton("header 1 value"));
-    }
-
-    @Test
-    public void headerTest2() {
+    public void singleHeaderTest() {
         framework.addAtmosphereHandler("/*", handler);
         AtmosphereResponse response = new AtmosphereResponseImpl.Builder()
                 .header("header 1", "header 1 value")
-                .header("header 2", "header 2 value")
-                .header("header 3", null)
+                .header("header 2", null)
                 .build();
         assertEquals(response.getHeaders("header 1"), Collections.singleton("header 1 value"));
+    }
+
+    @Test
+    public void headerNullValueTest() {
+        framework.addAtmosphereHandler("/*", handler);
+        AtmosphereResponse response = new AtmosphereResponseImpl.Builder()
+                .header("header 1", "header 1 value")
+                .header("header 2", null)
+                .build();
+        assertEquals(response.getHeaders("header 2"), Collections.singleton(null));
+    }
+
+    @Test
+    public void missingHeaderTest() {
+        framework.addAtmosphereHandler("/*", handler);
+        AtmosphereResponse response = new AtmosphereResponseImpl.Builder()
+                .header("header 1", "header 1 value")
+                .header("header 2", null)
+                .build();
+
+        assertEquals(response.getHeaders("header 3"), null);
     }
 }


### PR DESCRIPTION
…null` if header not found

This tests and fixes the issue as observed