### PR TITLE
Resolve an issue with the servlet mapping for JSR 356

### DIFF
--- a/modules/runtime/src/main/java/org/atmosphere/container/JSR356AsyncSupport.java
+++ b/modules/runtime/src/main/java/org/atmosphere/container/JSR356AsyncSupport.java
@@ -23,9 +23,6 @@ import org.atmosphere.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.servlet.ServletContext;
 import javax.websocket.DeploymentException;
 import javax.websocket.HandshakeResponse;
@@ -36,8 +33,9 @@ import javax.websocket.server.ServerEndpointConfig;
 public class JSR356AsyncSupport extends Servlet30CometSupport {
 
     private static final Logger logger = LoggerFactory.getLogger(JSR356AsyncSupport.class);
+    private static final String PATH = "/{path";
     private final AtmosphereConfigurator configurator;
-    
+
     public JSR356AsyncSupport(AtmosphereConfig config) {
         this(config, config.getServletContext());
     }
@@ -63,46 +61,26 @@ public class JSR356AsyncSupport extends Servlet30CometSupport {
         String servletPath = config.getInitParameter(ApplicationConfig.JSR356_MAPPING_PATH);
         if (servletPath == null) {
             servletPath = IOUtils.guestServletPath(config);
-            if (servletPath.equals("/") || servletPath.equals("/*")) {
-                servletPath = "";
+            if (servletPath.equals("") || servletPath.equals("/") || servletPath.equals("/*")) {
+                servletPath = PATH +"}";
             }
         }
         logger.info("JSR 356 Mapping path {}", servletPath);
         configurator = new AtmosphereConfigurator(config.framework());
 
-        // Register endpoints at
-        // /servletPath
-        // /servletPath/
-        // /servletPath/{path1}
-        // /servletPath/{path1}/
-        // /servletPath/{path1}/{path2}
-        // etc with up to `pathLength` parameters 
-
         StringBuilder b = new StringBuilder(servletPath);
-        List<String> endpointPaths = new ArrayList<>();
-        endpointPaths.add(servletPath);
         for (int i = 0; i < pathLength; i++) {
-            b.append("/");
-            endpointPaths.add(b.toString());
-            b.append("{path" + i + "}");
-            endpointPaths.add(b.toString());
-        }
-
-        for (String endpointPath : endpointPaths) {
-            if ("".equals(endpointPath)) {
-                // Spec says: The path is always non-null and always begins with a leading "/".
-                // Root mapping is covered by /{path1}
-                continue;
-            }
             try {
-                ServerEndpointConfig endpointConfig = ServerEndpointConfig.Builder.create(JSR356Endpoint.class, endpointPath).configurator(configurator).build();
-                container.addEndpoint(endpointConfig);
+                container.addEndpoint(ServerEndpointConfig.Builder.create(JSR356Endpoint.class, b.toString()).configurator(configurator).build());
             } catch (DeploymentException e) {
                 logger.warn("Duplicate Servlet Mapping Path {}. Use {} init-param to prevent this message", servletPath, ApplicationConfig.JSR356_MAPPING_PATH);
                 logger.trace("", e);
                 servletPath = IOUtils.guestServletPath(config);
                 logger.warn("Duplicate guess {}", servletPath, e);
+                b.setLength(0);
+                b.append(servletPath);
             }
+            b.append(PATH).append(i).append("}");
         }
     }
 

--- a/modules/runtime/src/main/java/org/atmosphere/util/IOUtils.java
+++ b/modules/runtime/src/main/java/org/atmosphere/util/IOUtils.java
@@ -56,7 +56,7 @@ import static org.atmosphere.runtime.HeaderConfig.X_ATMO_BINARY;
 public class IOUtils {
     private final static Logger logger = LoggerFactory.getLogger(IOUtils.class);
     private final static List<String> knownClasses;
-    private final static Pattern SERVLET_PATH_PATTERN = Pattern.compile("([\\/]?[\\w-[.]]+|[\\/]\\*\\*)+");
+    private final static Pattern SERVLET_PATH_PATTERN = Pattern.compile("([/]?[\\w-+.]+|[/]\\*\\*)+");
 
     static {
         knownClasses = new ArrayList<String>() {

--- a/modules/runtime/src/test/java/org/atmosphere/util/IOUtilsTest.java
+++ b/modules/runtime/src/test/java/org/atmosphere/util/IOUtilsTest.java
@@ -17,6 +17,7 @@ package org.atmosphere.util;
 
 import org.testng.annotations.Test;
 
+import static org.atmosphere.util.IOUtils.getCleanedServletPath;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -26,20 +27,14 @@ public class IOUtilsTest {
 
     @Test
     public void testGetCleanedServletPath() {
-        String testFullPath;
-        String testCleanedPath;
-
-        testFullPath = "/foo/bar/*";
-        testCleanedPath = IOUtils.getCleanedServletPath(testFullPath);
-        assertEquals(testCleanedPath, "/foo/bar");
-
-        testFullPath = "foo/bar/**/*";
-        testCleanedPath = IOUtils.getCleanedServletPath(testFullPath);
-        assertEquals(testCleanedPath, "/foo/bar/**");
-
-        testFullPath = "/com.zyxabc.abc.Abc/gwtCometEvent*";
-        testCleanedPath = IOUtils.getCleanedServletPath(testFullPath);
-        assertEquals(testCleanedPath, "/com.zyxabc.abc.Abc/gwtCometEvent");
+        assertEquals(getCleanedServletPath("/foo/bar/*"), "/foo/bar");
+        assertEquals(getCleanedServletPath("/foo/bar/"), "/foo/bar");
+        assertEquals(getCleanedServletPath("foo"), "/foo");
+        assertEquals(getCleanedServletPath("/foo/"), "/foo");
+        assertEquals(getCleanedServletPath("foo/bar/**/*"), "/foo/bar/**");
+        assertEquals(getCleanedServletPath("/com.zyxabc.abc.Abc/gwtCometEvent*"), "/com.zyxabc.abc.Abc/gwtCometEvent");
+        assertEquals(getCleanedServletPath("/com.abc_Abc-abc/"), "/com.abc_Abc-abc");
+        assertEquals(getCleanedServletPath("/com.abc_Abc-abc+bca/"), "/com.abc_Abc-abc+bca");
     }
 
 }


### PR DESCRIPTION
After some digging about #2316 (and #2326) I came to a conclusion that servlet mapping with trailing slash is incorrect in `JSR 356` [1]. The mapping value must have a leading '/' and should not contain empty parts:
> The value attribute must be a Java string that is a partial URI or URI-template (level-1), with a leading
‘/’. For a definition of URI-templates, see [6]. The implementation uses the value attribute to deploy the
endpoint to the URI space of the websocket implementation. The implementation must treat the value as relative to the root URI of the websocket implementation in determining a match against the request URI of an incoming opening handshake request. [WSC-4.1.1-2] The semantics of matching for annotated endpoints is the same as was defined in the previous chapter. The value attribute is mandatory; the implementation must reject a missing or malformed path at deployment time [WSC-4.1.1-3].

The trailing slash can be ignored or treated as missed part, as we saw in a Tomcat's implementation (#2320). Up to #2316 everything worked correctly: the `/mapping/` was cleared on `/mapping` and were not registering templates with trailing slash.

This PR:
- Reverts #2316 (for master brach).
- Fixes a regexp for the servlet path cleaning: remove an unclosed character class.
- Allows '+' as part of servlet path segment (see [2]).
- Adds more test cases for the fixed regexp.

[1] https://jcp.org/aboutJava/communityprocess/mrel/jsr356/index.html
[2] https://www.w3.org/Addressing/URL/url-spec.txt