### PR TITLE
AtmosphereResourceImpl is modified to use only the "uuid()" method to refer uuid

### DIFF
--- a/modules/runtime/src/main/java/org/atmosphere/runtime/AtmosphereResourceImpl.java
+++ b/modules/runtime/src/main/java/org/atmosphere/runtime/AtmosphereResourceImpl.java
@@ -132,7 +132,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
                 s = tmp != null && !tmp.equalsIgnoreCase("0") ? tmp : null;
             }
         }
-        uuid = s == null ? config.uuidProvider().generateUuid() : s;
+        this.setUUID( s == null ? config.uuidProvider().generateUuid() : s );
 
         if (config.isSupportSession()) {
             // Keep a reference to an HttpSession in case the associated request get recycled by the underlying container.
@@ -147,6 +147,10 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
         closeOnCancel = config.getInitParameter(ApplicationConfig.CLOSE_STREAM_ON_CANCEL, false);
         return this;
     }
+
+    protected void setUUID( String uuid ) {
+    	this.uuid = uuid;
+	}
 
 
     protected void register() {
@@ -632,10 +636,10 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
     @Override
     public AtmosphereResource notifyListeners(AtmosphereResourceEvent event) {
         if (listeners.isEmpty() && config.framework().atmosphereResourceListeners().isEmpty()) {
-            logger.trace("No listener with {}", uuid);
+            logger.trace("No listener with {}", uuid());
             return this;
         }
-        logger.trace("Invoking listener {} for {}", listeners, uuid);
+        logger.trace("Invoking listener {} for {}", listeners, uuid());
 
         Action oldAction = action;
         try {
@@ -793,7 +797,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
         try {
             if (!isCancelled.getAndSet(true)) {
                 suspended.set(false);
-                logger.trace("Cancelling {}", uuid);
+                logger.trace("Cancelling {}", uuid());
 
                 if (config.getBroadcasterFactory() != null) {
                     removeFromAllBroadcasters();
@@ -832,7 +836,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
     }
 
     private void unregister() {
-        config.resourcesFactory().remove(uuid);
+        config.resourcesFactory().remove(uuid());
     }
 
     public void _destroy() {
@@ -856,7 +860,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
     public String toString() {
         try {
             return "AtmosphereResource{" +
-                    "\n\t uuid=" + uuid +
+                    "\n\t uuid=" + uuid() +
                     ",\n\t transport=" + transport() +
                     ",\n\t isInScope=" + isInScope +
                     ",\n\t isResumed=" + isResumed() +
@@ -869,7 +873,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
                     '}';
         } catch (NullPointerException ex) {
             // Prevent logger
-            return "AtmosphereResourceImpl{" + uuid + "}";
+            return "AtmosphereResourceImpl{" + uuid() + "}";
         }
     }
 
@@ -995,14 +999,14 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
 
         AtmosphereResourceImpl that = (AtmosphereResourceImpl) o;
 
-        if (uuid != null ? !uuid.equals(that.uuid) : that.uuid != null) return false;
+        if (uuid() != null ? !uuid().equals(that.uuid()) : that.uuid() != null) return false;
 
         return true;
     }
 
     @Override
     public int hashCode() {
-        return uuid != null ? uuid.hashCode() : 0;
+        return uuid() != null ? uuid().hashCode() : 0;
     }
 
     public boolean getAndSetInClosingPhase() {

--- a/modules/runtime/src/main/java/org/atmosphere/runtime/AtmosphereResourceImpl.java
+++ b/modules/runtime/src/main/java/org/atmosphere/runtime/AtmosphereResourceImpl.java
@@ -132,7 +132,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
                 s = tmp != null && !tmp.equalsIgnoreCase("0") ? tmp : null;
             }
         }
-        this.setUUID( s == null ? config.uuidProvider().generateUuid() : s );
+        setUUID(s == null ? config.uuidProvider().generateUuid() : s);
 
         if (config.isSupportSession()) {
             // Keep a reference to an HttpSession in case the associated request get recycled by the underlying container.
@@ -148,9 +148,9 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
         return this;
     }
 
-    protected void setUUID( String uuid ) {
-    	this.uuid = uuid;
-	}
+    protected void setUUID(String uuid) {
+        this.uuid = uuid;
+    }
 
 
     protected void register() {


### PR DESCRIPTION
It helps to create custom AtmosphereResource with its own "uuid" by overriding AtmosphereResourceImpl.