### PR TITLE
Fix issue #2354

### DIFF
--- a/modules/runtime/src/main/java/org/atmosphere/runtime/AtmosphereResourceImpl.java
+++ b/modules/runtime/src/main/java/org/atmosphere/runtime/AtmosphereResourceImpl.java
@@ -647,7 +647,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
                 if (!disconnected.getAndSet(true)) {
                     onDisconnect(event);
                 } else {
-                    logger.trace("Skipping notification, already disconnected {}", event.getResource().uuid());
+                    logger.trace("Skipping notification, already disconnected {}", event.getResource() != null ? event.getResource().uuid() : uuid());
                 }
             } else if (event.isResuming() || event.isResumedOnTimeout()) {
                 onResume(event);


### PR DESCRIPTION
When trace a notification received on a disconnect resource, check if event has a resource before look for uuid, if not, fallback to own uuid.