### PR TITLE
Update Tomcat 7 version to 7.0.93 (runnable on Java 11)

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/TomcatWebSocketUtil.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/TomcatWebSocketUtil.java
@@ -250,7 +250,7 @@ public class TomcatWebSocketUtil {
         } catch (UnsupportedEncodingException e) {
             throw new ServletException(e);
         }
-        String result = org.apache.catalina.util.Base64.encode(sha1Helper.digest(WS_ACCEPT));
+        String result = org.apache.tomcat.util.codec.binary.Base64.encodeBase64String(sha1Helper.digest(WS_ACCEPT));
 
         sha1Helpers.add(sha1Helper);
 

--- a/pom.xml
+++ b/pom.xml
@@ -595,7 +595,7 @@
         <jetty9_2-version>9.2.13.v20150730</jetty9_2-version>
         <jetty9_3-version>9.3.19.v20170502</jetty9_3-version>
         <tomcat-version>6.0.35</tomcat-version>
-        <tomcat7-version>7.0.35</tomcat7-version>
+        <tomcat7-version>7.0.93</tomcat7-version>
         <shade-version>1.2.1</shade-version>
         <felix-version>2.3.7</felix-version>
         <ahc.version>1.7.7</ahc.version>


### PR DESCRIPTION
According to https://tomcat.apache.org/tomcat-7.0-doc/changelog.html#Tomcat%207.0.93%20(violetagg)/Other, Tomcat 7.0.93 is capable to compile and execute on Java 11.

This PR updates the Tomcat 7 dependency to Tomcat 7.0.93 and replaces the deprecated org.apache.catalina.util.Base64 with org.apache.tomcat.util.codec.binary.Base64, thus enabling Atmosphere 2.5.x to run on Java 11.