### PR TITLE
Fixes #2383

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
@@ -572,7 +572,7 @@ public class DefaultBroadcaster implements Broadcaster {
     protected void deliverPush(Deliver deliver, boolean rec) {
         recentActivity.set(true);
 
-        String prevMessage = deliver.message.toString();
+        Object prevMessage = deliver.message;
         if (rec && !delayedBroadcast.isEmpty()) {
             Iterator<Deliver> i = delayedBroadcast.iterator();
             StringBuilder b = new StringBuilder();


### PR DESCRIPTION
DefaultBroadcaster#deliverPush() caches the message, sends the push, and then restores the message to the Deliver object, since it may mutate the message inside the object. This changes the logic to cache the raw message, rather than message.toString().