### PR TITLE
Handling cookies problem in Tomcat 9.0.27

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
@@ -216,7 +216,10 @@ public class JSR356Endpoint extends Endpoint {
                 }
             }
 
-            List<String> cookieHeaders = handshakeHeaders.get("Cookie");
+            List<String> cookieHeaders = handshakeHeaders.get("cookie");
+            if (cookieHeaders == null) {
+                cookieHeaders = handshakeHeaders.get("Cookie");
+            }
             Set<Cookie> cookies = null;
             if (cookieHeaders != null) {
                 cookies = new HashSet<Cookie>();


### PR DESCRIPTION
When WebSocket connection is established to Spring Boot 2 application, org.atmosphere.container.JSR356Endpoint does NOT properly handle request cookies.
As a result AtmosphereRequest does not contain cookies at all although cookies are available in the request header...
Wrong header name was used "Cookie" instead of  "cookie"