### PR TITLE
add content type to first response

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
@@ -843,5 +843,13 @@ public interface ApplicationConfig {
      * Value: org.atmosphere.cpr.AsynchronousProcessor.closeOnCancel
      */
     java.lang.String CLOSE_STREAM_ON_CANCEL = "org.atmosphere.cpr.AsynchronousProcessor.closeOnCancel";
+
+    /**
+     * Set content-type header in the first response.
+     * See {@link org.atmosphere.cpr.AtmosphereFramework#configureRequestResponse}
+     * no default value
+     * value : text/plain; charset=utf-8
+     */
+    String CONTENT_TYPE_FIRST_RESPONSE = "org.atmosphere.cpr.contentTypeFirstResponse";
 }
 

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -2040,6 +2040,7 @@ public class AtmosphereFramework {
             s = UUID.randomUUID().toString();
             res.setHeader(HeaderConfig.X_FIRST_REQUEST, "true");
             res.setHeader(X_ATMOSPHERE_TRACKING_ID, s);
+            res.setHeader("Content-Type", "text/plain; charset=utf-8");
         } else {
             // This may breaks 1.0.0 application because the WebSocket's associated AtmosphereResource will
             // all have the same UUID, and retrieving the original one for WebSocket, so we don't set it at all.

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -98,6 +98,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.atmosphere.cpr.ApplicationConfig.CONTENT_TYPE_FIRST_RESPONSE;
 import static org.atmosphere.cpr.ApplicationConfig.ALLOW_QUERYSTRING_AS_REQUEST;
 import static org.atmosphere.cpr.ApplicationConfig.ATMOSPHERE_HANDLER;
 import static org.atmosphere.cpr.ApplicationConfig.ATMOSPHERE_HANDLER_MAPPING;
@@ -2040,7 +2041,10 @@ public class AtmosphereFramework {
             s = UUID.randomUUID().toString();
             res.setHeader(HeaderConfig.X_FIRST_REQUEST, "true");
             res.setHeader(X_ATMOSPHERE_TRACKING_ID, s);
-            res.setHeader("Content-Type", "text/plain; charset=utf-8");
+            String contentType = config.getInitParameter(CONTENT_TYPE_FIRST_RESPONSE);
+            if (contentType != null) {
+                res.setHeader("Content-Type", contentType);
+            }
         } else {
             // This may breaks 1.0.0 application because the WebSocket's associated AtmosphereResource will
             // all have the same UUID, and retrieving the original one for WebSocket, so we don't set it at all.


### PR DESCRIPTION
Content-type header are missing to first response. we use atmosphere-projet 2.2.13 
[ from Atmosphere 2312](https://github.com/Atmosphere/atmosphere/issues/2312)

It is possible to release a new version and push it to Maven Central ?

thank's
