### PR TITLE
fix dependency conflict issue

### DIFF
--- a/modules/cpr/pom.xml
+++ b/modules/cpr/pom.xml
@@ -312,6 +312,11 @@
             <version>20180130</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-websocket</artifactId>
+            <version>7.6.10.v20130312</version>
+        </dependency>
     </dependencies>
 </project>
     


### PR DESCRIPTION
[#2415 ](https://github.com/Atmosphere/atmosphere/issues/2415) dependency conflict issue for org.eclipse.jetty:jetty-http:jar