### PR TITLE
:bug: Avoid adding length prefix for padding #2364

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/client/TrackMessageSizeInterceptor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/client/TrackMessageSizeInterceptor.java
@@ -145,6 +145,11 @@ public class TrackMessageSizeInterceptor extends AtmosphereInterceptorAdapter {
 
                     if (cb.length() == 0) {
                         return responseDraft;
+                    } else if (cb.charAt(0) == ' ') {
+                        if (cb.toString().trim().isEmpty()) {
+                            // This is likely padding written by PaddingAtmosphereInterceptor
+                            return responseDraft;
+                        }
                     }
 
                     AtmosphereResource r = response.resource();


### PR DESCRIPTION
This reverts the semantic change done in 7cb3e9cac383e0cd9ddfea639339e872bbd2b049
and #2364 while trying to keep the optimization it did.