### PR TITLE
Marking quarkus as optional in the OSGI MANIFEST

### DIFF
--- a/modules/cpr/pom.xml
+++ b/modules/cpr/pom.xml
@@ -56,6 +56,7 @@
                             javax.enterprise*;resolution:=optional,
                             javax.inject*;resolution:=optional,
                             weblogic.websocket*;resolution:=optional,
+                            io.quarkus.runtime*;resolution:=optional,
                             *,
                         </Import-Package>
                         <Export-Package>


### PR DESCRIPTION
Quarkus is defined as optional in JSR356AsyncSupport hence the OSGI
metadata should reflect that.

Fixes #2453