### PR TITLE
Make jnlp requirement optional for OSGi

### DIFF
--- a/modules/cpr/pom.xml
+++ b/modules/cpr/pom.xml
@@ -57,6 +57,7 @@
                             javax.inject*;resolution:=optional,
                             weblogic.websocket*;resolution:=optional,
                             io.quarkus.runtime*;resolution:=optional,
+                            javax.jnlp*;resolution:=optional,
                             *,
                         </Import-Package>
                         <Export-Package>


### PR DESCRIPTION
Currently the generated OSGi manifest lists javax.jnlp as dependency,
while the code specifies this as optional. This change will make the
usage of this package also optional.

Relevant code:

 private boolean isRunningJavaWebStart() {
        boolean hasJNLP = false;
        try {
            Class.forName("javax.jnlp.ServiceManager");
            hasJNLP = true;
        } catch (ClassNotFoundException ex) {
            hasJNLP = false;
        }
        return hasJNLP;
    }

This change will only affect the generated OSGi manifest.