### PR TITLE
Remove usage of jnlp usage

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/util/annotation/AnnotationDetector.java
+++ b/modules/cpr/src/main/java/org/atmosphere/util/annotation/AnnotationDetector.java
@@ -336,12 +336,6 @@ public final class AnnotationDetector {
                             vfs(url, packageName, streams);
                         }
                     }
-                } else if (isRunningJavaWebStart()) {
-                    try {
-                        loadJarContent((JarURLConnection) url.openConnection(), packageName, streams);
-                    } catch (ClassCastException cce) {
-                        throw new AssertionError("Not a File: " + url.toExternalForm());
-                    }
                 } else {
                     // Resource in Jar File
                     File jarFile;
@@ -410,17 +404,6 @@ public final class AnnotationDetector {
         }
 
         return retval;
-    }
-
-    private boolean isRunningJavaWebStart() {
-        boolean hasJNLP = false;
-        try {
-            Class.forName("javax.jnlp.ServiceManager");
-            hasJNLP = true;
-        } catch (ClassNotFoundException ex) {
-            hasJNLP = false;
-        }
-        return hasJNLP;
     }
 
     private void loadJarContent(JarURLConnection url, String packageName, Set<InputStream> streams) throws IOException {


### PR DESCRIPTION
Jnlp has been deprecated in Java 11. This change removes the supporting
code in the atmosphere runtime.

Fixes #2457