### PR TITLE
org.atmosphere.jersey.util should be optional in the OSGi manifest

### DIFF
--- a/modules/cpr/pom.xml
+++ b/modules/cpr/pom.xml
@@ -58,6 +58,7 @@
                             weblogic.websocket*;resolution:=optional,
                             io.quarkus.runtime*;resolution:=optional,
                             javax.jnlp*;resolution:=optional,
+                            org.atmosphere.jersey.util*;resolution:=optional,
                             *,
                         </Import-Package>
                         <Export-Package>


### PR DESCRIPTION
org.atmosphere.jersey.util is not a mandatory requirement for the
runtime module. This change updates the generated OSGi manifest to
reflect that.

Fixes #2461