### PR TITLE
Set testng library with resolution optional

### DIFF
--- a/modules/cpr/pom.xml
+++ b/modules/cpr/pom.xml
@@ -59,6 +59,7 @@
                             io.quarkus.runtime*;resolution:=optional,
                             javax.jnlp*;resolution:=optional,
                             org.atmosphere.jersey.util*;resolution:=optional,
+                            org.testng;resolution:=optional,
                             *,
                         </Import-Package>
                         <Export-Package>
@@ -323,4 +324,4 @@
         </dependency>
     </dependencies>
 </project>
-    
+


### PR DESCRIPTION
atmosphere-runtime requires testng lib even if not used in runtime