### PR TITLE
#2468: added IDLE_EMPTY_DESTROY broadcaster lifecycle policy

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterLifeCyclePolicy.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterLifeCyclePolicy.java
@@ -31,6 +31,7 @@ public class BroadcasterLifeCyclePolicy {
     public final static BroadcasterLifeCyclePolicy IDLE_RESUME = new BroadcasterLifeCyclePolicy(ATMOSPHERE_RESOURCE_POLICY.IDLE_RESUME);
     public final static BroadcasterLifeCyclePolicy EMPTY = new BroadcasterLifeCyclePolicy(ATMOSPHERE_RESOURCE_POLICY.EMPTY);
     public final static BroadcasterLifeCyclePolicy EMPTY_DESTROY = new BroadcasterLifeCyclePolicy(ATMOSPHERE_RESOURCE_POLICY.EMPTY_DESTROY);
+    public final static BroadcasterLifeCyclePolicy IDLE_EMPTY_DESTROY = new BroadcasterLifeCyclePolicy(ATMOSPHERE_RESOURCE_POLICY.IDLE_EMPTY_DESTROY);
     public final static BroadcasterLifeCyclePolicy NEVER = new BroadcasterLifeCyclePolicy(ATMOSPHERE_RESOURCE_POLICY.NEVER);
 
     public enum ATMOSPHERE_RESOURCE_POLICY {
@@ -68,6 +69,13 @@ public class BroadcasterLifeCyclePolicy {
          * {@link org.atmosphere.cpr.Broadcaster#destroy()} will be invoked
          */
         EMPTY_DESTROY,
+
+        /**
+         * If there is no {@link org.atmosphere.cpr.AtmosphereResource} associated with the Broadcaster when the idle time expires,
+         * destroy the Broadcaster. This operation removes the Broadcaster from its associated {@link org.atmosphere.cpr.BroadcasterFactory}.
+         * {@link org.atmosphere.cpr.Broadcaster#destroy()} will be invoked
+         */
+        IDLE_EMPTY_DESTROY,
 
         /**
          * Never release or destroy the {@link org.atmosphere.cpr.Broadcaster}.

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcasterFactory.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcasterFactory.java
@@ -33,6 +33,7 @@ import static org.atmosphere.cpr.ApplicationConfig.BROADCASTER_POLICY_TIMEOUT;
 import static org.atmosphere.cpr.BroadcasterLifeCyclePolicy.ATMOSPHERE_RESOURCE_POLICY.EMPTY;
 import static org.atmosphere.cpr.BroadcasterLifeCyclePolicy.ATMOSPHERE_RESOURCE_POLICY.EMPTY_DESTROY;
 import static org.atmosphere.cpr.BroadcasterLifeCyclePolicy.ATMOSPHERE_RESOURCE_POLICY.IDLE;
+import static org.atmosphere.cpr.BroadcasterLifeCyclePolicy.ATMOSPHERE_RESOURCE_POLICY.IDLE_EMPTY_DESTROY;
 import static org.atmosphere.cpr.BroadcasterLifeCyclePolicy.ATMOSPHERE_RESOURCE_POLICY.IDLE_DESTROY;
 import static org.atmosphere.cpr.BroadcasterLifeCyclePolicy.ATMOSPHERE_RESOURCE_POLICY.IDLE_RESUME;
 import static org.atmosphere.cpr.BroadcasterLifeCyclePolicy.ATMOSPHERE_RESOURCE_POLICY.NEVER;
@@ -105,6 +106,8 @@ public class DefaultBroadcasterFactory implements BroadcasterFactory {
             policy = new BroadcasterLifeCyclePolicy.Builder().policy(IDLE_DESTROY).idleTimeInMS(maxIdleTime).build();
         } else if (IDLE_RESUME.name().equalsIgnoreCase(broadcasterLifeCyclePolicy)) {
             policy = new BroadcasterLifeCyclePolicy.Builder().policy(IDLE_RESUME).idleTimeInMS(maxIdleTime).build();
+        } else if (IDLE_EMPTY_DESTROY.name().equalsIgnoreCase(broadcasterLifeCyclePolicy)) {
+            policy = new BroadcasterLifeCyclePolicy.Builder().policy(IDLE_EMPTY_DESTROY).idleTimeInMS(maxIdleTime).build();
         } else if (NEVER.name().equalsIgnoreCase(broadcasterLifeCyclePolicy)) {
             policy = new BroadcasterLifeCyclePolicy.Builder().policy(NEVER).build();
         } else {

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/BroadcasterLifecyclePolicyTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/BroadcasterLifecyclePolicyTest.java
@@ -162,6 +162,26 @@ public class BroadcasterLifecyclePolicyTest {
         assertTrue(B.class.cast(b).destroy.get());
     }
 
+    @Test
+    public void testIdleEmptyDestroy() throws IOException, ServletException, InterruptedException {
+        B b = framework.getBroadcasterFactory().lookup(B.class, "/test", true);
+        b.setBroadcasterLifeCyclePolicy(
+                new BroadcasterLifeCyclePolicy.Builder().policy(BroadcasterLifeCyclePolicy.ATMOSPHERE_RESOURCE_POLICY.IDLE_EMPTY_DESTROY).idleTimeInMS(5000).build());
+        b.latch = new CountDownLatch(1);
+
+        AR ah = new AR();
+
+        framework.addAtmosphereHandler("/*", ah, b).init();
+        AtmosphereRequest request = new AtmosphereRequestImpl.Builder().pathInfo("/a").method("GET").build();
+        framework.doCometSupport(request, AtmosphereResponseImpl.newInstance());
+        b.removeAtmosphereResource(ah.resource);
+
+        b.latch.await();
+
+        assertFalse(B.class.cast(b).releaseExternalResources.get());
+        assertTrue(B.class.cast(b).destroy.get());
+    }
+
     public final static class AR implements AtmosphereHandler {
 
         private AtmosphereResource resource;


### PR DESCRIPTION
This commit adds a new lifecycle policy where a broadcaster is destroyed iff the idle time has expired + there are no resources (aka it's empty).