### PR TITLE
Issue2473 websocket handshake fails jetty10

### DIFF
--- a/modules/cpr/pom.xml
+++ b/modules/cpr/pom.xml
@@ -90,6 +90,7 @@
                             osgi.serviceloader;osgi.serviceloader=org.atmosphere.inject.CDIProducer,
                             osgi.serviceloader;osgi.serviceloader=org.atmosphere.inject.Injectable
                         </Provide-Capability>
+						<Eclipse-BuddyPolicy>registered</Eclipse-BuddyPolicy>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
PR for Issue 2473

- adds MANIFEST entry 'Eclipse-BuddyPolicy: registered' to allow loading of the custom AtmosphereHandler class from inside the atmosphere-runtime inside the equinox OSGi environment
- overwrites 3 methods in JSR356AsyncSupport.AtmosphereConfigurator to avoid RuntimeExceptions in equinox OSGi environment during initialization of javax.websocket implementation