### PR TITLE
Reduce log level for client errors in Jetty 9 WebSocket handler

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/Jetty9WebSocketHandler.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/Jetty9WebSocketHandler.java
@@ -118,7 +118,7 @@ public class Jetty9WebSocketHandler implements WebSocketListener {
 
     @Override
     public void onWebSocketError(Throwable e) {
-        logger.error("", e);
+        logger.debug("WebSocket client error", e);
         onWebSocketClose(1006, "Unexpected error");
     }
 


### PR DESCRIPTION
Client errors like timeouts and EOFs are currently logged as errors. While this is probably useful in development, on instances with many connected clients it will likely just be noise.

At the moment, log rows like these are quite common:

```
2022-11-14 08:11:32 ERROR [o.a.c.Jetty9WebSocketHandler] ::
org.eclipse.jetty.io.EofException: null
        at org.eclipse.jetty.io.ChannelEndPoint.flush(ChannelEndPoint.java:279)
        at org.eclipse.jetty.io.WriteFlusher.flush(WriteFlusher.java:422)
        at org.eclipse.jetty.io.WriteFlusher.write(WriteFlusher.java:277)
        at org.eclipse.jetty.io.AbstractEndPoint.write(AbstractEndPoint.java:381)
        at org.eclipse.jetty.websocket.common.io.FrameFlusher.flush(FrameFlusher.java:264)
        at org.eclipse.jetty.websocket.common.io.FrameFlusher.process(FrameFlusher.java:193)
        at org.eclipse.jetty.util.IteratingCallback.processing(IteratingCallback.java:241)
        at org.eclipse.jetty.util.IteratingCallback.iterate(IteratingCallback.java:223)
        at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.outgoingFrame(AbstractWebSocketConnection.java:581)
        at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.close(AbstractWebSocketConnection.java:181)
        at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:510)
        at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:440)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.io.IOException: Broken pipe
        at sun.nio.ch.FileDispatcherImpl.writev0(Native Method)
        at sun.nio.ch.SocketDispatcher.writev(SocketDispatcher.java:51)
        at sun.nio.ch.IOUtil.write(IOUtil.java:148)
        at sun.nio.ch.SocketChannelImpl.write(SocketChannelImpl.java:503)
        at java.nio.channels.SocketChannel.write(SocketChannel.java:502)
        at org.eclipse.jetty.io.ChannelEndPoint.flush(ChannelEndPoint.java:273)
        ... 22 common frames omitted
```

```
2022-11-14 08:11:25 ERROR [o.a.c.Jetty9WebSocketHandler] ::
org.eclipse.jetty.websocket.api.CloseException: java.util.concurrent.TimeoutException: Idle timeout expired: 300000/300000 ms
        at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onReadTimeout(AbstractWebSocketConnection.java:564)
        at org.eclipse.jetty.io.AbstractConnection.onFillInterestedFailed(AbstractConnection.java:172)
        at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillInterestedFailed(AbstractWebSocketConnection.java:539)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.failed(AbstractConnection.java:317)
        at org.eclipse.jetty.io.FillInterest.onFail(FillInterest.java:140)
        at org.eclipse.jetty.io.AbstractEndPoint.onIdleExpired(AbstractEndPoint.java:407)
        at org.eclipse.jetty.io.IdleTimeout.checkIdleTimeout(IdleTimeout.java:171)
        at org.eclipse.jetty.io.IdleTimeout.idleCheck(IdleTimeout.java:113)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.util.concurrent.TimeoutException: Idle timeout expired: 300000/300000 ms
        ... 9 common frames omitted
```