### PR TITLE
Fix NPE in InputStreamIterator

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/util/annotation/InputStreamIterator.java
+++ b/modules/cpr/src/main/java/org/atmosphere/util/annotation/InputStreamIterator.java
@@ -53,8 +53,8 @@ public final class InputStreamIterator {
      * in the specified order (depth first)
      */
     public InputStreamIterator(final InputStream... filesOrDirectories) {
-        addReverse(filesOrDirectories);
         stack = new LinkedList<>();
+        addReverse(filesOrDirectories);
         rootCount = 0;
     }
 


### PR DESCRIPTION
This broke in 412463d0ced979d9219cf6409d674b6ce79f09a1 when the field initialization was moved from the field declaration to the constructor.