### PR TITLE
JSR356Endpoint to read attributes from the handshake session

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
@@ -43,12 +43,14 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.atmosphere.cpr.ApplicationConfig.ALLOW_QUERYSTRING_AS_REQUEST;
 
@@ -224,6 +226,13 @@ public class JSR356Endpoint extends Endpoint {
                     cookies.addAll(CookieUtil.ServerCookieDecoder.STRICT.decode(cookieHeader));
             }
 
+            Enumeration<String> attributeNames = handshakeSession.getAttributeNames();
+            Map<String, Object> attributes = new ConcurrentHashMap<>();
+            while (attributeNames.hasMoreElements()) {
+                String attributeName = attributeNames.nextElement();
+                attributes.put(attributeName, handshakeSession.getAttribute(attributeName));
+            }
+
             request = new AtmosphereRequestImpl.Builder()
                     .requestURI(uri.getPath())
                     .requestURL(requestURL)
@@ -237,6 +246,7 @@ public class JSR356Endpoint extends Endpoint {
                     .userPrincipal(session.getUserPrincipal())
                     .remoteInetSocketAddress((Callable<InetSocketAddress>) () -> (InetSocketAddress) endpointConfig.getUserProperties().get(JAVAX_WEBSOCKET_ENDPOINT_REMOTE_ADDRESS))
                     .localInetSocketAddress((Callable<InetSocketAddress>) () -> (InetSocketAddress) endpointConfig.getUserProperties().get(JAVAX_WEBSOCKET_ENDPOINT_LOCAL_ADDRESS))
+                    .attributes(attributes)
                     .build()
                     .queryString(session.getQueryString());
 


### PR DESCRIPTION
Fixes https://github.com/Atmosphere/atmosphere/issues/2502

Behavior when using Jetty 9 was that attributes added by filters were copied from the HTTPRequest to the AtmosphereRequest. In Jetty 10, we are using JSR356Endpoint which does not copy the attributes. I couldn't figure out how to get the request attributes but instead will settle for using the attributes on the handshakeSession.