### PR TITLE
Set FEATURE_SECURE_PROCESSING for DocumentBuilderFactory to remediate XXE (XML External Entity Injection) vulnerabilities

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/util/AtmosphereConfigReader.java
+++ b/modules/cpr/src/main/java/org/atmosphere/util/AtmosphereConfigReader.java
@@ -29,6 +29,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.FileNotFoundException;
@@ -54,6 +55,7 @@ public class AtmosphereConfigReader {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             return parse(config, factory.newDocumentBuilder().parse(filename));
         } catch (SAXException | IOException | ParserConfigurationException e) {
             logger.error(e.getMessage(), e);
@@ -66,6 +68,7 @@ public class AtmosphereConfigReader {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             return parse(config, factory.newDocumentBuilder().parse(stream));
         } catch (SAXException | IOException | ParserConfigurationException e) {
             logger.error(e.getMessage(), e);


### PR DESCRIPTION
The **AtmosphereConfigReader** that is used to read Atmosphere configuration when initializing AtmosphereServlets parses XML files without security settings on or external entities disabled, which could lead to SSRF, information leaks, etc. 
Though so far it does not look like a critical one because malicious users has to get access to the application to inject XML files