### PR TITLE
Avoid NullPointerException if inputLine is 'null'

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -1139,7 +1139,8 @@ public class AtmosphereFramework {
                 boolean nextAvailable = false;
                 if (!newVersion.contains("SNAPSHOT")) {
                     try {
-                        while ((inputLine = in.readLine().trim()) != null) {
+                        while ((inputLine = in.readLine()) != null) {
+                            inputLine = inputLine.trim();
                             if (inputLine.startsWith("ATMO23_VERSION=")) {
                                 newVersion = inputLine.substring("ATMO23_VERSION=".length());
                             } else if (inputLine.startsWith("CLIENT3_VERSION=")) {


### PR DESCRIPTION
`null` check after `String.trim()` doesn't make sense. It leads to NPE