### PR TITLE
Fix ArrayIndexOutOfBoundsException in JavaScriptProtocol

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/interceptor/JavaScriptProtocol.java
+++ b/modules/cpr/src/main/java/org/atmosphere/interceptor/JavaScriptProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2025 Async-IO.org
+ * Copyright 2008-2026 Async-IO.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -46,13 +46,13 @@ import static org.atmosphere.cpr.HeaderConfig.X_ATMOSPHERE_ERROR;
 
 /**
  * <p>
- * An Interceptor that send back to a websocket and http client the value of {@link HeaderConfig#X_ATMOSPHERE_TRACKING_ID}.
+ * An Interceptor that sends back to a websocket and http client the value of {@link HeaderConfig#X_ATMOSPHERE_TRACKING_ID}.
  * </p>
  * <p/>
  * <p>
  * Moreover, if any {@link HeartbeatInterceptor} is installed, it provides the configured heartbeat interval in seconds
  * and the value to be sent for each heartbeat by the client. If not interceptor is installed, then "0" is sent to tell
- * he client to not send any heartbeat.
+ * the client to not send any heartbeat.
  * </p>
  *
  * @author Jeanfrancois Arcand
@@ -98,7 +98,7 @@ public class JavaScriptProtocol extends AtmosphereInterceptorAdapter {
                 String javascriptVersion = request.getHeader(HeaderConfig.X_ATMOSPHERE_FRAMEWORK);
                 int version = 0;
                 if (javascriptVersion != null) {
-                    version = parseVersion(javascriptVersion.split("-")[0]);
+                    version = tryParseVersion(javascriptVersion.split("-")[0]);
                 }
 
                 if (version < 221) {
@@ -194,10 +194,17 @@ public class JavaScriptProtocol extends AtmosphereInterceptorAdapter {
         return Action.CONTINUE;
     }
 
-    private static int parseVersion(String version) {
+    // Visible for testing
+    static int tryParseVersion(String version) {
         // Remove any qualifier if the version is 1.2.3.qualifier
         String[] parts = version.split("\\.");
-        return Integer.parseInt(parts[0] + parts[1] + parts[2]);
+        if (parts.length >= 3) {
+            try {
+                return Integer.parseInt(parts[0] + parts[1] + parts[2]);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return 0;
     }
 
     public String wsDelimiter() {

--- a/modules/cpr/src/test/java/org/atmosphere/interceptor/JavaScriptProtocolTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/interceptor/JavaScriptProtocolTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2008-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.interceptor;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.atmosphere.interceptor.JavaScriptProtocol.tryParseVersion;
+import static org.testng.Assert.assertEquals;
+
+public class JavaScriptProtocolTest {
+
+    @DataProvider(name = "versions")
+    public Object[][] versions() {
+        return new Object[][]{
+                // Valid input
+                {"2.2.1", 221},
+                {"2.2.1.beta", 221},
+                {"1.0.10", 1010},
+                {"3.0.0.RC1", 300},
+                {"0.0.0.snapshot", 0},
+                {"1.2.3.snapshot.x", 123},
+
+                // Invalid input
+                {"1...", 0},
+                {"2.", 0},
+                {"2.2", 0},
+                {"1.2.a", 0},
+                {"invalid", 0},
+                {"", 0}
+        };
+    }
+
+    @Test(dataProvider = "versions")
+    public void testTryParseVersion(String version, int expected) {
+        assertEquals(tryParseVersion(version), expected);
+    }
+}


### PR DESCRIPTION
Safe parsing of the protocol version in the JavaScriptProtocol interceptor to prevent ArrayIndexOutOfBoundsException caused by malformed input.