### PR TITLE
Respect init parameter for WebSocket protocol even some classes can be

### DIFF
--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -1543,8 +1543,9 @@ public class AtmosphereFramework {
                     detectSupportedFramework(sc);
                 }
             }
-
-            autoDetectWebSocketHandler(sc.getServletContext(), urlC);
+            if (!initParams.containsKey(ApplicationConfig.WEBSOCKET_PROTOCOL)) {
+                autoDetectWebSocketHandler(sc.getServletContext(), urlC);
+            }
         } catch (Throwable t) {
             throw new ServletException(t);
         }


### PR DESCRIPTION
automatically detected on the classpath

fixes #2534

there are several ways to tackle this issue. here is one simple way.
I'm not sure how I could write easily a test for this use case.