### PR TITLE
refactor: JDK 21 modernization — records, sealed types, decomposition, bug fixes

### DIFF
--- a/atmosphere.js/src/core/atmosphere.ts
+++ b/atmosphere.js/src/core/atmosphere.ts
@@ -30,6 +30,7 @@ import { LongPollingTransport } from '../transports/long-polling';
 import { StreamingTransport } from '../transports/streaming';
 import { BaseTransport } from '../transports/base';
 import { logger } from '../utils/logger';
+import { VERSION } from '../version';
 
 /**
  * Main Atmosphere client class.
@@ -39,7 +40,7 @@ import { logger } from '../utils/logger';
  * retry with a different transport on failure.
  */
 export class Atmosphere {
-  readonly version = '5.0.0';
+  readonly version = VERSION;
   private subscriptions = new Map<string, Subscription>();
   private subscriptionId = 0;
   private config: AtmosphereConfig;

--- a/atmosphere.js/src/hooks/react-native/index.ts
+++ b/atmosphere.js/src/hooks/react-native/index.ts
@@ -18,6 +18,10 @@
 export { setupReactNative, isReactNativeSetup } from '../../react-native/platform';
 export type { RNCapabilities, SetupReactNativeOptions } from '../../react-native/platform';
 
+// Shared core hook for building custom hooks
+export { useAtmosphereCore } from '../shared/useAtmosphereCore';
+export type { UseAtmosphereCoreResult, CoreSubscriptionHandlers } from '../shared/useAtmosphereCore';
+
 // RN-aware hooks
 export { useAtmosphereRN } from './useAtmosphereRN';
 export type { UseAtmosphereRNOptions, UseAtmosphereRNResult, BackgroundBehavior } from './useAtmosphereRN';

--- a/atmosphere.js/src/hooks/react-native/useAtmosphereRN.ts
+++ b/atmosphere.js/src/hooks/react-native/useAtmosphereRN.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { AppState } from 'react-native';
 import type {
   AtmosphereRequest,
@@ -23,6 +23,7 @@ import type {
 } from '../../types';
 import { useAtmosphereContext } from '../react/provider';
 import { getRegisteredNetInfo } from '../../react-native/platform';
+import { useAtmosphereCore } from '../shared/useAtmosphereCore';
 
 /**
  * Background behavior when the React Native app is not in the foreground.
@@ -50,6 +51,9 @@ export interface UseAtmosphereRNResult<T> {
   data: T | null;
   error: Error | null;
   push: (message: string | object | ArrayBuffer) => void;
+  disconnect: () => Promise<void>;
+  suspend: () => void;
+  resume: () => Promise<void>;
   isConnected: boolean;
   isInternetReachable: boolean;
 }
@@ -67,7 +71,7 @@ export interface UseAtmosphereRNResult<T> {
  * Requires an {@link AtmosphereProvider} ancestor.
  *
  * ```tsx
- * const { data, state, push, isConnected } = useAtmosphereRN<ChatMessage>({
+ * const { data, state, push, disconnect, isConnected } = useAtmosphereRN<ChatMessage>({
  *   request: { url: 'https://example.com/chat', transport: 'websocket' },
  *   backgroundBehavior: 'suspend',
  * });
@@ -79,78 +83,24 @@ export function useAtmosphereRN<T = unknown>(
   const atmosphere = useAtmosphereContext();
   const { request, enabled = true, backgroundBehavior = 'suspend' } = options;
 
-  const [state, setState] = useState<ConnectionState>('disconnected');
-  const [data, setData] = useState<T | null>(null);
-  const [error, setError] = useState<Error | null>(null);
   const [isConnected, setIsConnected] = useState(true);
   const [isInternetReachable, setIsInternetReachable] = useState(true);
 
-  const subRef = useRef<Subscription | null>(null);
   const backgroundBehaviorRef = useRef(backgroundBehavior);
   backgroundBehaviorRef.current = backgroundBehavior;
 
   // Track whether we need to reconnect on foreground
   const wasBackgroundedRef = useRef(false);
 
-  // --- Core subscription lifecycle ---
-  useEffect(() => {
-    if (!enabled) return;
-
-    let cancelled = false;
-
-    (async () => {
-      try {
-        const sub = await atmosphere.subscribe<T>(request, {
-          open: () => {
-            if (!cancelled) setState('connected');
-          },
-          message: (response) => {
-            if (!cancelled) {
-              setState('connected');
-              setData(response.responseBody);
-            }
-          },
-          close: () => {
-            if (!cancelled) setState('closed');
-          },
-          error: (err) => {
-            if (!cancelled) {
-              setState('error');
-              setError(err);
-            }
-          },
-          reconnect: () => {
-            if (!cancelled) setState('reconnecting');
-          },
-        });
-        if (!cancelled) {
-          subRef.current = sub;
-          setState(sub.state);
-        } else {
-          await sub.close();
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setState('error');
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      subRef.current?.close();
-      subRef.current = null;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [atmosphere, request.url, request.transport, enabled]);
+  // --- Core subscription lifecycle (shared with useAtmosphere) ---
+  const core = useAtmosphereCore<T>(atmosphere, request, undefined, enabled);
 
   // --- AppState integration ---
   useEffect(() => {
     if (!AppState) return;
 
     const handleAppState = (nextState: string) => {
-      const sub = subRef.current;
+      const sub = core.subRef.current;
       if (!sub) return;
 
       if (nextState === 'background' || nextState === 'inactive') {
@@ -173,7 +123,7 @@ export function useAtmosphereRN<T = unknown>(
 
     const subscription = AppState.addEventListener('change', handleAppState);
     return () => subscription.remove();
-  }, []);
+  }, [core.subRef]);
 
   // --- NetInfo integration (optional, requires setupReactNative({ netInfo })) ---
   useEffect(() => {
@@ -187,7 +137,7 @@ export function useAtmosphereRN<T = unknown>(
       setIsConnected(connected);
       setIsInternetReachable(reachable);
 
-      const sub = subRef.current;
+      const sub = core.subRef.current;
       if (!sub) return;
 
       if (!connected) {
@@ -200,25 +150,22 @@ export function useAtmosphereRN<T = unknown>(
     });
 
     return () => unsubscribe();
-  }, []);
-
-  const push = useCallback(
-    (message: string | object | ArrayBuffer) => {
-      subRef.current?.push(message);
-    },
-    [],
-  );
+  }, [core.subRef]);
 
   return useMemo(
     () => ({
-      subscription: subRef.current,
-      state,
-      data,
-      error,
-      push,
+      subscription: core.subscription,
+      state: core.state,
+      data: core.data,
+      error: core.error,
+      push: core.push,
+      disconnect: core.disconnect,
+      suspend: core.suspend,
+      resume: core.resume,
       isConnected,
       isInternetReachable,
     }),
-    [state, data, error, push, isConnected, isInternetReachable],
+    [core.subscription, core.state, core.data, core.error, core.push,
+     core.disconnect, core.suspend, core.resume, isConnected, isInternetReachable],
   );
 }

--- a/atmosphere.js/src/hooks/react/index.ts
+++ b/atmosphere.js/src/hooks/react/index.ts
@@ -16,6 +16,9 @@
 
 export { AtmosphereProvider, useAtmosphereContext } from './provider';
 export { useAtmosphere } from './useAtmosphere';
+export type { UseAtmosphereOptions, UseAtmosphereResult } from './useAtmosphere';
+export { useAtmosphereCore } from '../shared/useAtmosphereCore';
+export type { UseAtmosphereCoreResult, CoreSubscriptionHandlers } from '../shared/useAtmosphereCore';
 export { useRoom } from './useRoom';
 export { usePresence } from './usePresence';
 export { useStreaming } from './useStreaming';

--- a/atmosphere.js/src/hooks/react/useAtmosphere.ts
+++ b/atmosphere.js/src/hooks/react/useAtmosphere.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { useState, useEffect, useRef, useCallback } from 'react';
 import type {
   AtmosphereRequest,
   ConnectionState,
   Subscription,
 } from '../../types';
 import { useAtmosphereContext } from './provider';
+import { useAtmosphereCore } from '../shared/useAtmosphereCore';
 
 /**
  * Options for {@link useAtmosphere}.
@@ -46,6 +46,12 @@ export interface UseAtmosphereResult<T> {
   error: Error | null;
   /** Send a message on the subscription. */
   push: (message: string | object | ArrayBuffer) => void;
+  /** Close the subscription. */
+  disconnect: () => Promise<void>;
+  /** Suspend the underlying transport (pause without closing). */
+  suspend: () => void;
+  /** Resume a previously suspended transport. */
+  resume: () => Promise<void>;
 }
 
 /**
@@ -55,7 +61,7 @@ export interface UseAtmosphereResult<T> {
  * request URL or transport changes.
  *
  * ```tsx
- * const { data, state, push } = useAtmosphere<ChatMessage>({
+ * const { data, state, push, disconnect, suspend, resume } = useAtmosphere<ChatMessage>({
  *   request: { url: '/chat', transport: 'websocket' },
  * });
  * ```
@@ -68,76 +74,17 @@ export function useAtmosphere<T = unknown>(
   const atmosphere = useAtmosphereContext();
   const { request, enabled = true } = options;
 
-  const [state, setState] = useState<ConnectionState>('disconnected');
-  const [data, setData] = useState<T | null>(null);
-  const [error, setError] = useState<Error | null>(null);
-  const subRef = useRef<Subscription | null>(null);
-
-  useEffect(() => {
-    if (!enabled) return;
-
-    let cancelled = false;
-
-    (async () => {
-      try {
-        const sub = await atmosphere.subscribe<T>(request, {
-          open: () => {
-            if (!cancelled) setState('connected');
-          },
-          message: (response) => {
-            if (!cancelled) {
-              setState('connected');
-              setData(response.responseBody);
-            }
-          },
-          close: () => {
-            if (!cancelled) setState('closed');
-          },
-          error: (err) => {
-            if (!cancelled) {
-              setState('error');
-              setError(err);
-            }
-          },
-          reconnect: () => {
-            if (!cancelled) setState('reconnecting');
-          },
-        });
-        if (!cancelled) {
-          subRef.current = sub;
-          setState(sub.state);
-        } else {
-          await sub.close();
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setState('error');
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      subRef.current?.close();
-      subRef.current = null;
-    };
-    // Reconnect when URL or transport changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [atmosphere, request.url, request.transport, enabled]);
-
-  const push = useCallback(
-    (message: string | object | ArrayBuffer) => {
-      subRef.current?.push(message);
-    },
-    [],
-  );
+  const { subscription, state, data, error, push, disconnect, suspend, resume } =
+    useAtmosphereCore<T>(atmosphere, request, undefined, enabled);
 
   return {
-    subscription: subRef.current,
+    subscription,
     state,
     data,
     error,
     push,
+    disconnect,
+    suspend,
+    resume,
   };
 }

--- a/atmosphere.js/src/hooks/shared/useAtmosphereCore.ts
+++ b/atmosphere.js/src/hooks/shared/useAtmosphereCore.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2011-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type {
+  AtmosphereRequest,
+  ConnectionState,
+  Subscription,
+  SubscriptionHandlers,
+} from '../../types';
+import type { Atmosphere } from '../../core/atmosphere';
+
+/**
+ * Additional event handlers that callers can supply to
+ * {@link useAtmosphereCore} without altering the subscription lifecycle.
+ */
+export interface CoreSubscriptionHandlers<T> {
+  onOpen?: () => void;
+  onMessage?: (data: T) => void;
+  onClose?: () => void;
+  onError?: (error: Error) => void;
+  onReconnect?: () => void;
+}
+
+/**
+ * Return type of {@link useAtmosphereCore}.
+ *
+ * Contains the full subscription lifecycle state plus manual control
+ * methods (`disconnect`, `suspend`, `resume`) that let consumers manage
+ * the connection without reaching through the raw {@link Subscription}.
+ */
+export interface UseAtmosphereCoreResult<T> {
+  /** The active subscription, or null before connection. */
+  subscription: Subscription | null;
+  /** Current connection state. */
+  state: ConnectionState;
+  /** The last message received. */
+  data: T | null;
+  /** The last error, if any. */
+  error: Error | null;
+  /** Send a message on the subscription. */
+  push: (message: string | object | ArrayBuffer) => void;
+  /** Close the subscription. */
+  disconnect: () => Promise<void>;
+  /** Suspend the underlying transport (pause without closing). */
+  suspend: () => void;
+  /** Resume a previously suspended transport. */
+  resume: () => Promise<void>;
+  /** Ref to the current subscription (for platform-specific effects). */
+  subRef: React.RefObject<Subscription | null>;
+}
+
+/**
+ * Shared React hook that manages an Atmosphere subscription lifecycle.
+ *
+ * This is the foundational hook used by both `useAtmosphere` (web) and
+ * `useAtmosphereRN` (React Native). It handles:
+ * - State management (`subscription`, `state`, `data`, `error`)
+ * - The subscribe effect with open/message/close/error/reconnect handlers
+ * - Cleanup on unmount or dependency change
+ * - Manual control callbacks (`push`, `disconnect`, `suspend`, `resume`)
+ *
+ * Platform-specific hooks layer additional behavior (e.g. AppState,
+ * NetInfo) on top of this core.
+ */
+export function useAtmosphereCore<T = unknown>(
+  atmosphere: Atmosphere,
+  request: AtmosphereRequest,
+  handlers?: CoreSubscriptionHandlers<T>,
+  enabled: boolean = true,
+): UseAtmosphereCoreResult<T> {
+  const [state, setState] = useState<ConnectionState>('disconnected');
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const subRef = useRef<Subscription | null>(null);
+
+  // Keep handlers in a ref so the effect doesn't re-run when handlers change
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const subscriptionHandlers: SubscriptionHandlers<T> = {
+          open: () => {
+            if (!cancelled) {
+              setState('connected');
+              handlersRef.current?.onOpen?.();
+            }
+          },
+          message: (response) => {
+            if (!cancelled) {
+              setState('connected');
+              setData(response.responseBody);
+              handlersRef.current?.onMessage?.(response.responseBody);
+            }
+          },
+          close: () => {
+            if (!cancelled) {
+              setState('closed');
+              handlersRef.current?.onClose?.();
+            }
+          },
+          error: (err) => {
+            if (!cancelled) {
+              setState('error');
+              setError(err);
+              handlersRef.current?.onError?.(err);
+            }
+          },
+          reconnect: () => {
+            if (!cancelled) {
+              setState('reconnecting');
+              handlersRef.current?.onReconnect?.();
+            }
+          },
+        };
+
+        const sub = await atmosphere.subscribe<T>(request, subscriptionHandlers);
+        if (!cancelled) {
+          subRef.current = sub;
+          setState(sub.state);
+        } else {
+          await sub.close();
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setState('error');
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      subRef.current?.close();
+      subRef.current = null;
+    };
+    // Reconnect when URL or transport changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [atmosphere, request.url, request.transport, enabled]);
+
+  const push = useCallback(
+    (message: string | object | ArrayBuffer) => {
+      subRef.current?.push(message);
+    },
+    [],
+  );
+
+  const disconnect = useCallback(async () => {
+    const sub = subRef.current;
+    if (sub) {
+      await sub.close();
+      subRef.current = null;
+    }
+  }, []);
+
+  const suspend = useCallback(() => {
+    subRef.current?.suspend();
+  }, []);
+
+  const resume = useCallback(async () => {
+    const sub = subRef.current;
+    if (sub) {
+      await sub.resume();
+    }
+  }, []);
+
+  return {
+    subscription: subRef.current,
+    state,
+    data,
+    error,
+    push,
+    disconnect,
+    suspend,
+    resume,
+    subRef,
+  };
+}

--- a/atmosphere.js/src/version.ts
+++ b/atmosphere.js/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '5.0.4';
+export const VERSION = '5.0.7';

--- a/atmosphere.js/tests/unit/atmosphere.test.ts
+++ b/atmosphere.js/tests/unit/atmosphere.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Atmosphere } from '../../src/core/atmosphere';
+import { VERSION } from '../../src/version';
 
 describe('Atmosphere', () => {
   let atmosphere: Atmosphere;
@@ -9,7 +10,7 @@ describe('Atmosphere', () => {
   });
 
   it('should have correct version', () => {
-    expect(atmosphere.version).toBe('5.0.0');
+    expect(atmosphere.version).toBe(VERSION);
   });
 
   it('should create subscription with generated ID', async () => {

--- a/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
+++ b/modules/cpr/src/main/java/org/atmosphere/container/JSR356Endpoint.java
@@ -255,7 +255,7 @@ public class JSR356Endpoint extends Endpoint {
                     .remoteInetSocketAddress(() -> (InetSocketAddress) endpointConfig.getUserProperties().get(JAVAX_WEBSOCKET_ENDPOINT_REMOTE_ADDRESS), disableDnsLookups)
                     .localInetSocketAddress(() -> (InetSocketAddress) endpointConfig.getUserProperties().get(JAVAX_WEBSOCKET_ENDPOINT_LOCAL_ADDRESS), disableDnsLookups)
                     .attributes(attributes)
-                    .isSSecure(session.isSecure())
+                    .isSecure(session.isSecure())
                     .build()
                     .queryString(session.getQueryString());
 

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/Action.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/Action.java
@@ -21,7 +21,7 @@ package org.atmosphere.cpr;
  *
  * @author Jeanfrancois Arcand
  */
-public final class Action {
+public record Action(TYPE type, long timeout) {
     /**
      * The action's type.
      */
@@ -67,84 +67,19 @@ public final class Action {
         SKIP_ATMOSPHEREHANDLER
     }
 
-    public final static Action CANCELLED = new Action(TYPE.CANCELLED, true);
-    public final static Action CONTINUE = new Action(TYPE.CONTINUE, true);
-    public final static Action CREATED = new Action(TYPE.CREATED, true);
-    public final static Action RESUME = new Action(TYPE.RESUME, true);
-    public final static Action SUSPEND = new Action(TYPE.SUSPEND, true);
-    public final static Action DESTROYED = new Action(TYPE.DESTROYED, true);
-    public final static Action SKIP_ATMOSPHEREHANDLER = new Action(TYPE.SKIP_ATMOSPHEREHANDLER);
-
-    private long timeout;
-    private TYPE type;
-    private boolean immutable;
-
-    public Action() {
-        this(TYPE.CREATED);
-    }
+    public static final Action CANCELLED = new Action(TYPE.CANCELLED);
+    public static final Action CONTINUE = new Action(TYPE.CONTINUE);
+    public static final Action CREATED = new Action(TYPE.CREATED);
+    public static final Action RESUME = new Action(TYPE.RESUME);
+    public static final Action SUSPEND = new Action(TYPE.SUSPEND);
+    public static final Action DESTROYED = new Action(TYPE.DESTROYED);
+    public static final Action SKIP_ATMOSPHEREHANDLER = new Action(TYPE.SKIP_ATMOSPHEREHANDLER);
 
     public Action(TYPE type) {
         this(type, -1L);
     }
 
-    public Action(TYPE type, boolean immutable) {
-        this(type, -1L);
-        this.immutable = immutable;
-    }
-
-    public Action(TYPE type, long timeout) {
-        this.timeout = timeout;
-        this.type = type;
-    }
-
-    public Action.TYPE type() {
-        return type;
-    }
-
-    public Action type(Action.TYPE type) {
-        if (immutable) {
-            throw new IllegalStateException("immutable");
-        }
-        this.type = type;
-        return this;
-    }
-
-    public long timeout() {
-        return timeout;
-    }
-
-    public Action timeout(long timeout) {
-        if (immutable) {
-            throw new IllegalStateException("immutable");
-        }
-
-        this.timeout = timeout;
-        return this;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Action action = (Action) o;
-
-        if (timeout != action.timeout()) return false;
-        return type == action.type();
-    }
-
-    @Override
-    public int hashCode() {
-        int result = (int) (timeout ^ (timeout >>> 32));
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "Action{" +
-                "timeout=" + timeout +
-                ", type=" + type +
-                '}';
+    public Action() {
+        this(TYPE.CREATED);
     }
 }

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AnnotationScanningServletContainerInitializer.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AnnotationScanningServletContainerInitializer.java
@@ -52,6 +52,7 @@ import java.util.Set;
  * servlet context.
  *
  * NOTE: Any new Atmosphere's annotation must be hardcoded here.
+ * Source of truth: {@link AtmosphereAnnotations#coreAnnotations()}
  *
  * @author Stuart Douglas
  */

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/ApplicationConfig.java
@@ -1081,4 +1081,16 @@ public interface ApplicationConfig {
      * Value: org.atmosphere.kafka.group.id
      */
     String KAFKA_GROUP_ID = "org.atmosphere.kafka.group.id";
+    /**
+     * When set to {@code true}, Atmosphere will skip JVM-global system property
+     * modifications that are normally applied during initialization to work around
+     * container-specific issues (e.g., Tomcat strict servlet compliance).
+     * <p/>
+     * This is useful in multi-application environments or testing scenarios where
+     * mutating JVM-wide state is undesirable.
+     * <p/>
+     * Default: false (container patching is enabled)<br>
+     * Value: org.atmosphere.cpr.disableContainerPatching
+     */
+    String DISABLE_CONTAINER_PATCHING = "org.atmosphere.cpr.disableContainerPatching";
 }

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereAnnotations.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereAnnotations.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2008-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.cpr;
+
+import org.atmosphere.config.AtmosphereAnnotation;
+import org.atmosphere.config.service.AsyncSupportListenerService;
+import org.atmosphere.config.service.AsyncSupportService;
+import org.atmosphere.config.service.AtmosphereFrameworkListenerService;
+import org.atmosphere.config.service.AtmosphereHandlerService;
+import org.atmosphere.config.service.AtmosphereInterceptorService;
+import org.atmosphere.config.service.AtmosphereResourceFactoryService;
+import org.atmosphere.config.service.AtmosphereResourceListenerService;
+import org.atmosphere.config.service.AtmosphereService;
+import org.atmosphere.config.service.BroadcasterCacheInspectorService;
+import org.atmosphere.config.service.BroadcasterCacheListenerService;
+import org.atmosphere.config.service.BroadcasterCacheService;
+import org.atmosphere.config.service.BroadcasterFactoryService;
+import org.atmosphere.config.service.BroadcasterFilterService;
+import org.atmosphere.config.service.BroadcasterListenerService;
+import org.atmosphere.config.service.BroadcasterService;
+import org.atmosphere.config.service.EndpointMapperService;
+import org.atmosphere.config.service.ManagedService;
+import org.atmosphere.config.service.RoomService;
+import org.atmosphere.config.service.UUIDProviderService;
+import org.atmosphere.config.service.WebSocketFactoryService;
+import org.atmosphere.config.service.WebSocketHandlerService;
+import org.atmosphere.config.service.WebSocketProcessorService;
+import org.atmosphere.config.service.WebSocketProtocolService;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/**
+ * Single source of truth for all Atmosphere annotation types and their processor mappings.
+ *
+ * <p>All modules that need the list of core Atmosphere annotations should reference this
+ * class rather than maintaining their own copy. The one exception is
+ * {@link AnnotationScanningServletContainerInitializer} whose {@code @HandlesTypes}
+ * annotation requires compile-time class literals and cannot delegate to a runtime list.</p>
+ *
+ * @author Jeanfrancois Arcand
+ */
+public final class AtmosphereAnnotations {
+
+    private AtmosphereAnnotations() {
+    }
+
+    private static final List<Class<? extends Annotation>> CORE_ANNOTATIONS = List.of(
+            AtmosphereHandlerService.class,
+            BroadcasterCacheService.class,
+            BroadcasterFilterService.class,
+            BroadcasterFactoryService.class,
+            BroadcasterService.class,
+            WebSocketFactoryService.class,
+            WebSocketHandlerService.class,
+            WebSocketProtocolService.class,
+            AtmosphereInterceptorService.class,
+            BroadcasterListenerService.class,
+            AsyncSupportService.class,
+            AsyncSupportListenerService.class,
+            WebSocketProcessorService.class,
+            BroadcasterCacheInspectorService.class,
+            ManagedService.class,
+            AtmosphereService.class,
+            EndpointMapperService.class,
+            BroadcasterCacheListenerService.class,
+            AtmosphereAnnotation.class,
+            AtmosphereResourceFactoryService.class,
+            AtmosphereFrameworkListenerService.class,
+            AtmosphereResourceListenerService.class,
+            UUIDProviderService.class,
+            RoomService.class
+    );
+
+    /**
+     * Returns the unmodifiable list of all core Atmosphere annotation types.
+     *
+     * @return the core annotations
+     */
+    public static List<Class<? extends Annotation>> coreAnnotations() {
+        return CORE_ANNOTATIONS;
+    }
+
+    /**
+     * Returns the fully-qualified class names of all core Atmosphere annotations.
+     * Useful for modules that work with string-based annotation names (e.g. Jandex {@code DotName}).
+     *
+     * @return the core annotation names
+     */
+    public static List<String> coreAnnotationNames() {
+        return CORE_ANNOTATIONS.stream()
+                .map(Class::getName)
+                .toList();
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereFramework.java
@@ -30,7 +30,6 @@ import org.atmosphere.util.EndpointMapper;
 import org.atmosphere.util.ExecutorsFactory;
 import org.atmosphere.util.IOUtils;
 import org.atmosphere.util.IntrospectionUtils;
-import org.atmosphere.util.ServletContextFactory;
 import org.atmosphere.util.UUIDProvider;
 import org.atmosphere.util.VoidServletConfig;
 import org.atmosphere.websocket.DefaultWebSocketProcessor;
@@ -145,7 +144,7 @@ public class AtmosphereFramework {
     protected final ClasspathScanner classpathScanner;
     public static final List<Class<? extends AtmosphereInterceptor>> DEFAULT_ATMOSPHERE_INTERCEPTORS =
             InterceptorRegistry.DEFAULT_ATMOSPHERE_INTERCEPTORS;
-    private IllegalStateException initializationError;
+    IllegalStateException initializationError;
 
     /**
      * An implementation of {@link AbstractReflectorAtmosphereHandler}.
@@ -215,7 +214,7 @@ public class AtmosphereFramework {
     /**
      * The order of addition is quite important here.
      */
-    private void populateBroadcasterType() {
+    void populateBroadcasterType() {
         broadcasterSetup.populateBroadcasterType();
     }
 
@@ -230,7 +229,7 @@ public class AtmosphereFramework {
     /**
      * The order of addition is quite important here.
      */
-    private void populateObjectFactoryType() {
+    void populateObjectFactoryType() {
         objectFactoryType.add(CDI_INJECTOR);
         objectFactoryType.add(SPRING_INJECTOR);
         objectFactoryType.add(GUICE_INJECTOR);
@@ -383,10 +382,12 @@ public class AtmosphereFramework {
     }
 
     /**
-     * Path specific container using their own property.
+     * Patch container-specific system properties to work around strict compliance modes.
+     * Delegates to {@link ContainerPatcher} which logs modifications and respects the
+     * {@link ApplicationConfig#DISABLE_CONTAINER_PATCHING} opt-out.
      */
     public void patchContainer() {
-        System.setProperty("org.apache.catalina.STRICT_SERVLET_COMPLIANCE", "false");
+        ContainerPatcher.patch(this);
     }
 
     /**
@@ -425,95 +426,7 @@ public class AtmosphereFramework {
     public AtmosphereFramework init(final ServletConfig sc, boolean wrap) throws ServletException {
         if (isInit) return this;
 
-        // Phase 0: Bootstrap
-        servletConfig(sc, wrap);
-        readSystemProperties();
-        populateBroadcasterType();
-        populateObjectFactoryType();
-        loadMetaService();
-        onPreInit();
-
-        try {
-            ServletContextFactory.getDefault().init(sc.getServletContext());
-
-            // Phase 1: Parse configuration
-            preventOOM();
-            doInitParams(servletConfig);
-            doInitParamsForWebSocket(servletConfig);
-            lookupDefaultObjectFactoryType();
-
-            if (logger.isTraceEnabled()) {
-                asyncSupportListener(newClassInstance(AsyncSupportListener.class, AsyncSupportListenerAdapter.class));
-            }
-            configureObjectFactory();
-
-            // Phase 2: Broadcaster infrastructure
-            configureAnnotationPackages();
-            configureBroadcasterFactory();
-            configureMetaBroadcaster();
-            configureAtmosphereResourceFactory();
-            if (isSessionSupportSpecified) {
-                sessionFactory();
-            }
-
-            // Phase 3: Classpath scanning
-            configureScanningPackage(servletConfig, ApplicationConfig.ANNOTATION_PACKAGE);
-            configureScanningPackage(servletConfig, FrameworkConfig.JERSEY2_SCANNING_PACKAGE);
-            configureScanningPackage(servletConfig, FrameworkConfig.JERSEY_SCANNING_PACKAGE);
-            defaultPackagesToScan();
-            installAnnotationProcessor(servletConfig);
-            autoConfigureService(servletConfig.getServletContext());
-
-            // Phase 4: Re-configure after annotations
-            configureBroadcasterFactory();
-            patchContainer();
-            configureBroadcaster();
-            loadConfiguration(servletConfig);
-
-            // Phase 5: Handler/interceptor initialization
-            initWebSocket();
-            initEndpointMapper();
-            initDefaultSerializer();
-            autoDetectContainer();
-            configureWebDotXmlAtmosphereHandler(servletConfig);
-            asyncSupport.init(servletConfig);
-            initAtmosphereHandler(servletConfig);
-            configureAtmosphereInterceptor(servletConfig);
-
-            // Phase 6: Finalization
-            analytics();
-            if (sc.getServletContext() != null) {
-                sc.getServletContext().setAttribute(BroadcasterFactory.class.getName(), broadcasterSetup.broadcasterFactory());
-            }
-
-            String s = config.getInitParameter(ApplicationConfig.BROADCASTER_SHARABLE_THREAD_POOLS);
-            if (s != null) {
-                sharedThreadPools = Boolean.parseBoolean(s);
-            }
-
-            this.shutdownHook = new Thread(AtmosphereFramework.this::destroy);
-            Runtime.getRuntime().addShutdownHook(this.shutdownHook);
-
-            if (logger.isInfoEnabled()) {
-                info();
-            }
-            if (initializationError != null) {
-                logger.trace("ContainerInitalizer exception. May not be an issue if Atmosphere started properly ", initializationError);
-            }
-            universe();
-        } catch (Throwable t) {
-            logger.error("Failed to initialize Atmosphere Framework", t);
-
-            if (t instanceof ServletException se) {
-                throw se;
-            }
-
-            throw new ServletException(t);
-        }
-        isInit = true;
-        config.initComplete();
-
-        onPostInit();
+        new FrameworkBootstrap(this).bootstrap(sc, wrap);
 
         return this;
     }
@@ -575,7 +488,7 @@ public class AtmosphereFramework {
         }
     }
 
-    private void info() {
+    void info() {
         FrameworkDiagnostics.info(this);
     }
 
@@ -586,7 +499,7 @@ public class AtmosphereFramework {
         Universe.framework(this);
     }
 
-    private void configureAnnotationPackages() {
+    void configureAnnotationPackages() {
         classpathScanner.configureAnnotationPackages();
     }
 
@@ -2023,7 +1936,7 @@ public class AtmosphereFramework {
         return broadcasterSetup.getOrCreateAtmosphereFactory();
     }
 
-    private AtmosphereFramework configureAtmosphereResourceFactory() {
+    AtmosphereFramework configureAtmosphereResourceFactory() {
         broadcasterSetup.configureAtmosphereResourceFactory();
         return this;
     }
@@ -2032,7 +1945,7 @@ public class AtmosphereFramework {
         return broadcasterSetup.metaBroadcaster();
     }
 
-    private AtmosphereFramework configureMetaBroadcaster() {
+    AtmosphereFramework configureMetaBroadcaster() {
         broadcasterSetup.configureMetaBroadcaster();
         return this;
     }
@@ -2067,7 +1980,7 @@ public class AtmosphereFramework {
         return this;
     }
 
-    private void initDefaultSerializer() {
+    void initDefaultSerializer() {
         broadcasterSetup.initDefaultSerializer();
     }
 

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereReflectiveTypes.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereReflectiveTypes.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2008-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.cpr;
+
+import java.util.List;
+
+/**
+ * Single source of truth for all Atmosphere types that require reflective access
+ * at runtime (GraalVM native image, Spring AOT, Quarkus native build).
+ *
+ * <p>Both the Spring Boot starter ({@code AtmosphereRuntimeHints}) and the Quarkus
+ * deployment processor ({@code AtmosphereProcessor}) should reference these lists
+ * instead of maintaining their own copies.</p>
+ *
+ * @author Jeanfrancois Arcand
+ * @see AtmosphereAnnotations
+ */
+public final class AtmosphereReflectiveTypes {
+
+    private AtmosphereReflectiveTypes() {
+    }
+
+    private static final String ANNOTATION_PKG = "org.atmosphere.annotation.";
+
+    /**
+     * Core Atmosphere framework types that are instantiated reflectively at runtime
+     * via {@code IOUtils.loadClass}, {@code getDeclaredConstructor}, or ServiceLoader.
+     * This covers framework infrastructure, injectable SPI implementations,
+     * async support, default interceptors, WebSocket internals, and the
+     * annotation processor.
+     */
+    private static final List<String> CORE_TYPES = List.of(
+            // Framework infrastructure
+            "org.atmosphere.cpr.AtmosphereFramework",
+            "org.atmosphere.cpr.DefaultBroadcaster",
+            "org.atmosphere.cpr.DefaultBroadcasterFactory",
+            "org.atmosphere.cpr.DefaultAtmosphereResourceFactory",
+            "org.atmosphere.cpr.DefaultMetaBroadcaster",
+            "org.atmosphere.cpr.DefaultAtmosphereResourceSessionFactory",
+
+            // Core classes instantiated via newClassInstance / getDeclaredConstructor
+            "org.atmosphere.cpr.AtmosphereResourceImpl",
+            "org.atmosphere.cpr.AtmosphereRequestImpl",
+            "org.atmosphere.cpr.AtmosphereResponseImpl",
+            "org.atmosphere.config.managed.ManagedAtmosphereHandler",
+            "org.atmosphere.config.managed.AtmosphereHandlerServiceInterceptor",
+            "org.atmosphere.cpr.DefaultAtmosphereObjectFactory",
+
+            // Injectable SPI implementations (loaded via ServiceLoader)
+            "org.atmosphere.inject.InjectableObjectFactory",
+            "org.atmosphere.inject.AtmosphereProducers",
+            "org.atmosphere.inject.AtmosphereConfigInjectable",
+            "org.atmosphere.inject.AtmosphereFrameworkInjectable",
+            "org.atmosphere.inject.AtmosphereResourceFactoryInjectable",
+            "org.atmosphere.inject.AtmosphereResourceSessionFactoryInjectable",
+            "org.atmosphere.inject.BroadcasterFactoryInjectable",
+            "org.atmosphere.inject.MetaBroadcasterInjectable",
+            "org.atmosphere.inject.WebSocketFactoryInjectable",
+            "org.atmosphere.inject.PostConstructIntrospector",
+            "org.atmosphere.inject.BroadcasterIntrospector",
+            "org.atmosphere.inject.AtmosphereResourceIntrospector",
+            "org.atmosphere.inject.AtmosphereRequestIntrospector",
+            "org.atmosphere.inject.AtmosphereResponseIntrospector",
+            "org.atmosphere.inject.AtmosphereResourceEventIntrospector",
+            "org.atmosphere.inject.PathParamIntrospector",
+
+            // AsyncSupport implementations (resolved by DefaultAsyncSupportResolver)
+            "org.atmosphere.container.JSR356AsyncSupport",
+            "org.atmosphere.container.Servlet30CometSupport",
+
+            // WebSocket internals
+            "org.atmosphere.websocket.DefaultWebSocketProcessor",
+            "org.atmosphere.websocket.DefaultWebSocketFactory",
+            "org.atmosphere.websocket.protocol.SimpleHttpProtocol",
+            "org.atmosphere.container.JSR356Endpoint",
+
+            // Default interceptors (loaded by name via IOUtils.loadClass)
+            "org.atmosphere.interceptor.CorsInterceptor",
+            "org.atmosphere.interceptor.CacheHeadersInterceptor",
+            "org.atmosphere.interceptor.PaddingAtmosphereInterceptor",
+            "org.atmosphere.interceptor.AndroidAtmosphereInterceptor",
+            "org.atmosphere.interceptor.HeartbeatInterceptor",
+            "org.atmosphere.interceptor.SSEAtmosphereInterceptor",
+            "org.atmosphere.interceptor.JavaScriptProtocol",
+            "org.atmosphere.interceptor.WebSocketMessageSuspendInterceptor",
+            "org.atmosphere.interceptor.OnDisconnectInterceptor",
+            "org.atmosphere.interceptor.IdleResourceInterceptor",
+            "org.atmosphere.interceptor.SuspendTrackerInterceptor",
+
+            // Annotation processor
+            "org.atmosphere.cpr.DefaultAnnotationProcessor"
+    );
+
+    /**
+     * Annotation processor classes instantiated reflectively by {@code AnnotationHandler}.
+     * Each processor handles a specific Atmosphere annotation at runtime.
+     */
+    private static final List<String> ANNOTATION_PROCESSORS = List.of(
+            ANNOTATION_PKG + "AsyncSupportListenerServiceProcessor",
+            ANNOTATION_PKG + "AsyncSupportServiceProcessor",
+            ANNOTATION_PKG + "AtmosphereFrameworkServiceProcessor",
+            ANNOTATION_PKG + "AtmosphereHandlerServiceProcessor",
+            ANNOTATION_PKG + "AtmosphereInterceptorServiceProcessor",
+            ANNOTATION_PKG + "AtmosphereResourceFactoryServiceProcessor",
+            ANNOTATION_PKG + "AtmosphereResourceListenerServiceProcessor",
+            ANNOTATION_PKG + "AtmosphereServiceProcessor",
+            ANNOTATION_PKG + "BroadcastFilterServiceProcessor",
+            ANNOTATION_PKG + "BroadcasterCacheInspectorServiceProcessor",
+            ANNOTATION_PKG + "BroadcasterCacheListenererviceProcessor",
+            ANNOTATION_PKG + "BroadcasterCacheServiceProcessor",
+            ANNOTATION_PKG + "BroadcasterFactoryServiceProcessor",
+            ANNOTATION_PKG + "BroadcasterListenerServiceProcessor",
+            ANNOTATION_PKG + "BroadcasterServiceProcessor",
+            ANNOTATION_PKG + "EndpointMapperServiceProcessor",
+            ANNOTATION_PKG + "ManagedServiceProcessor",
+            ANNOTATION_PKG + "UUIDProviderServiceProcessor",
+            ANNOTATION_PKG + "WebSocketFactoryServiceProcessor",
+            ANNOTATION_PKG + "WebSocketHandlerServiceProcessor",
+            ANNOTATION_PKG + "WebSocketProcessorServiceProcessor",
+            ANNOTATION_PKG + "WebSocketProtocolServiceProcessor"
+    );
+
+    /**
+     * Pool implementation types that depend on optional commons-pool2.
+     * These should only be registered when {@code org.apache.commons.pool2.PooledObjectFactory}
+     * is available on the classpath.
+     */
+    private static final List<String> POOL_TYPES = List.of(
+            "org.atmosphere.pool.UnboundedApachePoolableProvider",
+            "org.atmosphere.pool.BoundedApachePoolableProvider"
+    );
+
+    /**
+     * Returns the fully-qualified class names of all core Atmosphere types that
+     * require reflective access at runtime.
+     *
+     * @return unmodifiable list of core type names
+     */
+    public static List<String> coreTypes() {
+        return CORE_TYPES;
+    }
+
+    /**
+     * Returns the fully-qualified class names of all Atmosphere annotation processor
+     * classes that are instantiated reflectively by {@code AnnotationHandler}.
+     *
+     * @return unmodifiable list of annotation processor type names
+     */
+    public static List<String> annotationProcessors() {
+        return ANNOTATION_PROCESSORS;
+    }
+
+    /**
+     * Returns the fully-qualified class names of pool implementation types that
+     * depend on optional commons-pool2.
+     *
+     * @return unmodifiable list of pool type names
+     */
+    public static List<String> poolTypes() {
+        return POOL_TYPES;
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequest.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequest.java
@@ -15,30 +15,15 @@
  */
 package org.atmosphere.cpr;
 
-import jakarta.servlet.AsyncContext;
-import jakarta.servlet.DispatcherType;
-import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletInputStream;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import jakarta.servlet.http.Part;
 
-import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.security.Principal;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -59,190 +44,9 @@ public interface AtmosphereRequest extends HttpServletRequest {
 
     AtmosphereRequest destroyable(boolean destroyable);
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getPathInfo();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getPathTranslated();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getQueryString();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getRemoteUser();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getRequestedSessionId();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getMethod();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Part getPart(String name) throws IOException, ServletException;
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Collection<Part> getParts() throws IOException, ServletException;
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getContentType();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    DispatcherType getDispatcherType();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getServletPath();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getRequestURI();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    StringBuffer getRequestURL();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Enumeration<String> getHeaders(String name);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    int getIntHeader(String name);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Enumeration<String> getHeaderNames();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    boolean authenticate(HttpServletResponse response) throws IOException, ServletException;
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getAuthType();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getContextPath();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Cookie[] getCookies();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    long getDateHeader(String name);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getHeader(String s);
-
     HttpServletRequest wrappedRequest();
 
     String getHeader(String s, boolean checkCase);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getParameter(String s);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Map<String, String[]> getParameterMap();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Enumeration<String> getParameterNames();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String[] getParameterValues(String s);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getProtocol();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    ServletInputStream getInputStream() throws IOException;
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    BufferedReader getReader() throws IOException;
-
-    /**
-     * {@inheritDoc}
-     */
-    @SuppressWarnings("deprecation")
-    @Override
-    String getRealPath(String path);
 
     /**
      * Add all headers contained within the Map.
@@ -300,210 +104,11 @@ public interface AtmosphereRequest extends HttpServletRequest {
     AtmosphereRequest requestURI(String requestURI);
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    void setAttribute(String s, Object o);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    void setCharacterEncoding(String env) throws UnsupportedEncodingException;
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    AsyncContext startAsync();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    AsyncContext startAsync(ServletRequest request, ServletResponse response);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    AsyncContext getAsyncContext();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Object getAttribute(String s);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    void removeAttribute(String name);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    HttpSession getSession();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    HttpSession getSession(boolean create);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Principal getUserPrincipal();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    boolean isRequestedSessionIdFromCookie();
-
-    /**
-     * {@inheritDoc}
-     */
-    @SuppressWarnings("deprecation")
-    @Override
-    boolean isRequestedSessionIdFromUrl();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    boolean isRequestedSessionIdFromURL();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    boolean isRequestedSessionIdValid();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    boolean isUserInRole(String role);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    void login(String username, String password) throws ServletException;
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    void logout() throws ServletException;
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getRemoteAddr();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getRemoteHost();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    int getRemotePort();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    RequestDispatcher getRequestDispatcher(String path);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getScheme();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getServerName();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    int getServerPort();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    ServletContext getServletContext();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    boolean isAsyncStarted();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    boolean isAsyncSupported();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    boolean isSecure();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getLocalName();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    int getLocalPort();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getLocalAddr();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Locale getLocale();
-
-    /**
      * The {@link AtmosphereResource} associated with this request.
      *
      * @return an {@link AtmosphereResource}
      */
     AtmosphereResource resource();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Enumeration<Locale> getLocales();
 
     /**
      * Dispatch the request asynchronously to container. The default is false.
@@ -513,17 +118,11 @@ public interface AtmosphereRequest extends HttpServletRequest {
     boolean dispatchRequestAsynchronously();
 
     /**
-     * Cjeck if this object can be destroyed. Default is true.
+     * Check if this object can be destroyed. Default is true.
      */
     boolean isDestroyable();
 
     AtmosphereRequest pathInfo(String pathInfo);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    Enumeration<String> getAttributeNames();
 
     /**
      * Return a subset of the attributes set on this AtmosphereRequest, set locally by the framework or by an application. Attributes added using this method
@@ -532,18 +131,6 @@ public interface AtmosphereRequest extends HttpServletRequest {
      * @return a {@linkLocalAttributes>}
      */
     LocalAttributes localAttributes();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    String getCharacterEncoding();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    int getContentLength();
 
     /**
      * Return the underlying {@link AtmosphereResource#uuid()}. May return "0" if no {@link AtmosphereResource}
@@ -556,14 +143,6 @@ public interface AtmosphereRequest extends HttpServletRequest {
     void destroy();
 
     void destroy(boolean force);
-
-    /**
-     * {@inheritDoc}
-     */
-    void setRequest(ServletRequest request);
-
-    @Override
-    String toString();
 
     String requestURL();
 
@@ -605,7 +184,7 @@ public interface AtmosphereRequest extends HttpServletRequest {
             return localAttributes.containsKey(key);
         }
     }
-    
+
     interface Builder {
         Builder destroyable(boolean destroyable);
 
@@ -679,7 +258,10 @@ public interface AtmosphereRequest extends HttpServletRequest {
 
         Builder authType(String authType);
 
+        @Deprecated
         Builder isSSecure(boolean isSecure);
+
+        Builder isSecure(boolean isSecure);
 
         Builder locale(Locale locale);
 

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequestImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereRequestImpl.java
@@ -18,7 +18,6 @@ package org.atmosphere.cpr;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.AsyncListener;
 import jakarta.servlet.DispatcherType;
-import jakarta.servlet.ReadListener;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
@@ -30,7 +29,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import jakarta.servlet.http.HttpUpgradeHandler;
 import jakarta.servlet.http.Part;
 import org.atmosphere.util.FakeHttpSession;
 import org.atmosphere.util.QueryStringDecoder;
@@ -87,15 +85,15 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
     private boolean queryComputed;
     private boolean cookieComputed;
     private volatile BufferedReader voidReader;
-    private final ServletInputStream voidStream = new IS(new ByteArrayInputStream(new byte[0]));
+    private final ServletInputStream voidStream = new InputStreamServletAdapter(new ByteArrayInputStream(new byte[0]));
     private AtomicBoolean streamSet = new AtomicBoolean();
     private AtomicBoolean readerSet = new AtomicBoolean();
     private String uuid;
     private boolean noopsAsyncContextStarted;
 
     private AtmosphereRequestImpl(Builder b) {
-        super(b.request == null ? new NoOpsRequest() : b.request);
-        if (b.request == null) b.request(new NoOpsRequest());
+        super(b.request == null ? new org.atmosphere.cpr.NoOpsRequest() : b.request);
+        if (b.request == null) b.request(new org.atmosphere.cpr.NoOpsRequest());
 
         this.b = b;
         this.uuid = resource() != null ? resource().uuid() : "0";
@@ -111,30 +109,30 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
     private void configureStream() {
         if (bis == null && !streamSet.getAndSet(true)) {
             if (b.inputStream != null) {
-                bis = new IS(b.inputStream);
+                bis = new InputStreamServletAdapter(b.inputStream);
             } else if (b.reader == null) {
-                if (b.body.dataBytes != null) {
-                    bis = new ByteInputStream(b.body.dataBytes, b.body.offset, b.body.length);
-                } else if (b.body.data != null) {
-                    byte[] bytes = b.body.data.getBytes(StandardCharsets.UTF_8);
-                    bis = new ByteInputStream(bytes, 0, bytes.length);
+                if (b.body.hasBytes()) {
+                    bis = new ByteArrayServletInputStream(b.body.asBytes(), b.body.byteOffset(), b.body.byteLength());
+                } else if (b.body.hasString()) {
+                    byte[] bytes = b.body.asString().getBytes(StandardCharsets.UTF_8);
+                    bis = new ByteArrayServletInputStream(bytes, 0, bytes.length);
                 }
             } else {
-                bis = new IS(new ReaderInputStream(b.reader));
+                bis = new InputStreamServletAdapter(new ReaderInputStream(b.reader));
             }
         }
     }
 
     private void configureReader() {
-        if (br == null && !readerSet.getAndSet(false)) {
+        if (br == null && !readerSet.getAndSet(true)) {
             if (b.reader != null) {
                 br = new BufferedReader(b.reader);
             } else if (b.inputStream == null) {
                 try {
-                    if (b.body.dataBytes != null) {
-                        br = new BufferedReader(new StringReader(new String(b.body.dataBytes, b.body.offset, b.body.length, b.encoding)));
-                    } else if (b.body.data != null) {
-                        br = new BufferedReader(new StringReader(b.body.data));
+                    if (b.body.hasBytes()) {
+                        br = new BufferedReader(new StringReader(new String(b.body.asBytes(), b.body.byteOffset(), b.body.byteLength(), b.encoding)));
+                    } else if (b.body.hasString()) {
+                        br = new BufferedReader(new StringReader(b.body.asString()));
                     }
                 } catch (UnsupportedEncodingException e) {
                     throw new RuntimeException(e);
@@ -452,9 +450,9 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
             configureStream();
             return bis == null ? (isNotNoOps() ? b.request.getInputStream() : voidStream) : bis;
         } else if (b.body.hasString()) {
-            bis = new IS(new ByteArrayInputStream(b.body.asString().getBytes()));
+            bis = new InputStreamServletAdapter(new ByteArrayInputStream(b.body.asString().getBytes()));
         } else if (b.body.hasBytes()) {
-            bis = new IS(new ByteArrayInputStream(b.body.asBytes(), b.body.offset, b.body.byteLength()));
+            bis = new InputStreamServletAdapter(new ByteArrayInputStream(b.body.asBytes(), b.body.byteOffset(), b.body.byteLength()));
         }
         return bis;
     }
@@ -467,7 +465,7 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
         } else if (b.body.hasString()) {
             br = new BufferedReader(new StringReader(body().asString()));
         } else if (b.body.hasBytes()) {
-            br = new BufferedReader(new StringReader(new String(body().asBytes(), body().byteOffset(), body().length)));
+            br = new BufferedReader(new StringReader(new String(body().asBytes(), body().byteOffset(), body().byteLength())));
         }
         return br;
     }
@@ -532,26 +530,26 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
 
     @Override
     public AtmosphereRequest body(String body) {
-        b.body = new Body(body, null, 0, 0);
+        b.body = new Body.StringBody(body);
         return this;
     }
 
     @Override
     public AtmosphereRequest body(byte[] bytes) {
-        b.body = new Body(null, bytes, 0, bytes.length);
+        b.body = new Body.BytesBody(bytes, 0, bytes.length);
         return this;
     }
 
     @Override
     public AtmosphereRequest body(InputStream body) {
-        bis = new IS(body);
+        bis = new InputStreamServletAdapter(body);
         br = new BufferedReader(new InputStreamReader(body));
         return this;
     }
 
     @Override
     public AtmosphereRequest body(Reader body) {
-        bis = new IS(new ReaderInputStream(body));
+        bis = new InputStreamServletAdapter(new ReaderInputStream(body));
         br = new BufferedReader(body);
         return this;
     }
@@ -577,34 +575,6 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
     public AtmosphereRequest requestURI(String requestURI) {
         b.requestURI = requestURI;
         return this;
-    }
-
-    private final static class ByteInputStream extends ServletInputStream {
-
-        private final ByteArrayInputStream bis;
-
-        public ByteInputStream(byte[] data, int offset, int length) {
-            this.bis = new ByteArrayInputStream(data, offset, length);
-        }
-
-        @Override
-        public int read() throws IOException {
-            return bis.read();
-        }
-
-        @Override
-        public boolean isFinished() {
-            return false;
-        }
-
-        @Override
-        public boolean isReady() {
-            return false;
-        }
-
-        @Override
-        public void setReadListener(ReadListener readListener) {
-        }
     }
 
     @Override
@@ -869,7 +839,7 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
     }
 
     private boolean isNotNoOps() {
-        return !(b.request instanceof NoOpsRequest);
+        return !(b.request instanceof org.atmosphere.cpr.NoOpsRequest);
     }
 
     @Override
@@ -1004,7 +974,7 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
     }
 
     public final static class Builder implements AtmosphereRequest.Builder {
-        private final static Body NULL_BODY = new Body(null, null, 0, 0);
+        private static final Body NULL_BODY = new Body.EmptyBody();
         private final ReentrantLock requestLock = new ReentrantLock();
         private HttpServletRequest request;
         private String pathInfo = "";
@@ -1168,7 +1138,7 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
 
         @Override
         public Builder body(byte[] dataBytes, int offset, int length) {
-            this.body = new Body(null, dataBytes, offset, length);
+            this.body = new Body.BytesBody(dataBytes, offset, length);
             return this;
         }
 
@@ -1201,7 +1171,7 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
 
         @Override
         public Builder body(String data) {
-            this.body = new Body(data, null, 0, 0);
+            this.body = new Body.StringBody(data);
             return this;
         }
 
@@ -1252,10 +1222,10 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
         @Override
         public Builder session(HttpSession session) {
             if (request == null) {
-                request = new NoOpsRequest();
+                request = new org.atmosphere.cpr.NoOpsRequest();
             }
 
-            if (request instanceof NoOpsRequest noOpsRequest) {
+            if (request instanceof org.atmosphere.cpr.NoOpsRequest noOpsRequest) {
                 noOpsRequest.fake = session;
             } else {
                 webSocketFakeSession = session;
@@ -1275,8 +1245,15 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
             return this;
         }
 
+        @Deprecated
         @Override
         public Builder isSSecure(boolean isSecure) {
+            this.isSecure = isSecure;
+            return this;
+        }
+
+        @Override
+        public Builder isSecure(boolean isSecure) {
             this.isSecure = isSecure;
             return this;
         }
@@ -1294,154 +1271,85 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
         }
     }
 
-    public final static class Body {
-        private final String data;
-        private final byte[] dataBytes;
-        private final int offset;
-        private final int length;
-        private final boolean isEmpty;
-
-        public Body(String data, byte[] dataBytes, int offset, int length) {
-            this.data = data;
-            this.dataBytes = dataBytes;
-            this.offset = offset;
-            this.length = length;
-            isEmpty = data == null && dataBytes == null;
-        }
+    public sealed interface Body permits Body.StringBody, Body.BytesBody, Body.EmptyBody {
 
         /**
          * True is the body is a String
          *
          * @return True is the body is a String
          */
-        public boolean hasString() {
-            return data != null;
-        }
+        boolean hasString();
 
         /**
          * True is the body is a byte array
          *
          * @return True is the body is a byte array
          */
-        public boolean hasBytes() {
-            return dataBytes != null;
-        }
+        boolean hasBytes();
 
         /**
          * Return the request body as a String. If the body was a byte array, this method will return null.
          *
          * @return the request body as a String. If the body was a byte array, this method will return null.
          */
-        public String asString() {
-            return data;
-        }
+        String asString();
 
         /**
          * Return the request body as a byte array. If the body was String, this method will return null.
          *
          * @return the request body as a byte array. If the body was String, this method will return null.
          */
-        public byte[] asBytes() {
-            return dataBytes;
-        }
+        byte[] asBytes();
 
         /**
          * The {@link #asBytes()} offset
          *
          * @return The {@link #asBytes()} offset
          */
-        public int byteOffset() {
-            return offset;
-        }
+        int byteOffset();
 
         /**
          * The {@link #asBytes()} length
          *
          * @return The {@link #asBytes()} length
          */
-        public int byteLength() {
-            return length;
-        }
+        int byteLength();
 
         /**
          * True if this object is empty
          *
          * @return True if this object is empty
          */
-        public boolean isEmpty() {
-            return isEmpty;
-        }
-    }
+        boolean isEmpty();
 
-    private final static class IS extends ServletInputStream {
-
-        private final InputStream innerStream;
-        private final ReentrantLock markLock = new ReentrantLock();
-
-        public IS(InputStream innerStream) {
-            super();
-            this.innerStream = innerStream;
+        record StringBody(String data) implements Body {
+            @Override public boolean hasString() { return true; }
+            @Override public boolean hasBytes() { return false; }
+            @Override public String asString() { return data; }
+            @Override public byte[] asBytes() { return null; }
+            @Override public int byteOffset() { return 0; }
+            @Override public int byteLength() { return 0; }
+            @Override public boolean isEmpty() { return false; }
         }
 
-        public int read() throws java.io.IOException {
-            return innerStream.read();
+        record BytesBody(byte[] data, int offset, int length) implements Body {
+            @Override public boolean hasString() { return false; }
+            @Override public boolean hasBytes() { return true; }
+            @Override public String asString() { return null; }
+            @Override public byte[] asBytes() { return data; }
+            @Override public int byteOffset() { return offset; }
+            @Override public int byteLength() { return length; }
+            @Override public boolean isEmpty() { return false; }
         }
 
-        public int read(byte[] bytes) throws java.io.IOException {
-            return innerStream.read(bytes);
-        }
-
-        public int read(byte[] bytes, int i, int i1) throws java.io.IOException {
-            return innerStream.read(bytes, i, i1);
-        }
-
-
-        public long skip(long l) throws java.io.IOException {
-            return innerStream.skip(l);
-        }
-
-        public int available() throws java.io.IOException {
-            return innerStream.available();
-        }
-
-        public void close() throws java.io.IOException {
-            innerStream.close();
-        }
-
-        public void mark(int i) {
-            markLock.lock();
-            try {
-                innerStream.mark(i);
-            } finally {
-                markLock.unlock();
-            }
-        }
-
-        public void reset() throws java.io.IOException {
-            markLock.lock();
-            try {
-                innerStream.reset();
-            } finally {
-                markLock.unlock();
-            }
-        }
-
-        public boolean markSupported() {
-            return innerStream.markSupported();
-        }
-
-        @Override
-        public boolean isFinished() {
-            return false;
-        }
-
-        @Override
-        public boolean isReady() {
-            return false;
-        }
-
-        @Override
-        public void setReadListener(ReadListener readListener) {
+        record EmptyBody() implements Body {
+            @Override public boolean hasString() { return false; }
+            @Override public boolean hasBytes() { return false; }
+            @Override public String asString() { return null; }
+            @Override public byte[] asBytes() { return null; }
+            @Override public int byteOffset() { return 0; }
+            @Override public int byteLength() { return 0; }
+            @Override public boolean isEmpty() { return true; }
         }
     }
 
@@ -1534,12 +1442,12 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
                 .session(session)
                 .principal(request.getUserPrincipal())
                 .authType(request.getAuthType())
-                .isSSecure(request.isSecure());
+                .isSecure(request.isSecure());
 
         if (loadInMemory) {
             String s = (String) attributeWithoutException(request, FrameworkConfig.THROW_EXCEPTION_ON_CLONED_REQUEST);
             boolean throwException = Boolean.parseBoolean(s);
-            r = new NoOpsRequest(throwException);
+            r = new org.atmosphere.cpr.NoOpsRequest(throwException);
             if (isWrapped) {
                 load(b.request, b);
             } else {
@@ -1551,395 +1459,17 @@ public class AtmosphereRequestImpl extends HttpServletRequestWrapper implements 
         return isWrapped ? (AtmosphereRequestImpl) request : b.build();
     }
 
-    public final static class NoOpsRequest implements HttpServletRequest {
-
-        private final boolean throwExceptionOnCloned;
-        public HttpSession fake;
-        private final static Enumeration<String> EMPTY_ENUM_STRING = Collections.enumeration(List.of());
-        private final static Enumeration<Locale> EMPTY_ENUM_LOCALE = Collections.enumeration(List.of());
-        private final static List<Part> EMPTY_ENUM_PART = List.of();
-        private final static Map<String, String[]> EMPTY_MAP_STRING = Map.of();
-        private final static String[] EMPTY_ARRAY = new String[0];
-        private final StringBuffer EMPTY_STRING_BUFFER = new StringBuffer();
-        private final static Cookie[] EMPTY_COOKIE = new Cookie[0];
-        private volatile BufferedReader voidReader;
-        private final ServletInputStream voidStream = new AtmosphereRequestImpl.IS(new ByteArrayInputStream(new byte[0]));
-
+    /**
+     * @deprecated Use {@link org.atmosphere.cpr.NoOpsRequest} directly instead.
+     */
+    @Deprecated
+    public static class NoOpsRequest extends org.atmosphere.cpr.NoOpsRequest {
         public NoOpsRequest() {
-            this.throwExceptionOnCloned = false;
+            super();
         }
 
         public NoOpsRequest(boolean throwExceptionOnCloned) {
-            this.throwExceptionOnCloned = throwExceptionOnCloned;
-        }
-
-        private BufferedReader getVoidReader() {
-            if (voidReader == null) {
-                voidReader = new BufferedReader(new StringReader(""));
-            }
-            return voidReader;
-        }
-
-        @Override
-        public boolean authenticate(HttpServletResponse response) {
-            return false;
-        }
-
-        @Override
-        public String getAuthType() {
-            return null;
-        }
-
-        @Override
-        public String getContextPath() {
-            return "";
-        }
-
-        @Override
-        public Cookie[] getCookies() {
-            return EMPTY_COOKIE;
-        }
-
-        @Override
-        public long getDateHeader(String name) {
-            return 0;
-        }
-
-        @Override
-        public String getHeader(String name) {
-            return null;
-        }
-
-        @Override
-        public Enumeration<String> getHeaderNames() {
-            return EMPTY_ENUM_STRING;
-        }
-
-        @Override
-        public Enumeration<String> getHeaders(String name) {
-            return EMPTY_ENUM_STRING;
-        }
-
-        @Override
-        public int getIntHeader(String name) {
-            return 0;
-        }
-
-        @Override
-        public String getMethod() {
-            return "GET";
-        }
-
-        @Override
-        public Part getPart(String name) throws IOException, ServletException {
-            return null;
-        }
-
-        @Override
-        public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
-            return null;
-        }
-
-        @Override
-        public Collection<Part> getParts() throws IOException, ServletException {
-            return EMPTY_ENUM_PART;
-        }
-
-        @Override
-        public String getPathInfo() {
-            return "";
-        }
-
-        @Override
-        public String getPathTranslated() {
-            return "";
-        }
-
-        @Override
-        public String getQueryString() {
-            return "";
-        }
-
-        @Override
-        public String getRemoteUser() {
-            return "";
-        }
-
-        @Override
-        public String getRequestedSessionId() {
-            return "";
-        }
-
-        @Override
-        public String getRequestURI() {
-            return "/";
-        }
-
-        @Override
-        public StringBuffer getRequestURL() {
-            return EMPTY_STRING_BUFFER;
-        }
-
-        @Override
-        public String getServletPath() {
-            return "";
-        }
-
-        @Override
-        public HttpSession getSession() {
-            return fake;
-        }
-
-        @Override
-        public String changeSessionId() {
-            return getSession(false).getId();
-        }
-
-        @Override
-        public HttpSession getSession(boolean create) {
-            if (create && fake == null) {
-                fake = new FakeHttpSession("", null, System.currentTimeMillis(), -1) {
-                    @Override
-                    public void invalidate() {
-                        fake = null;
-                        super.invalidate();
-                    }
-                };
-            }
-            return fake;
-        }
-
-        @Override
-        public Principal getUserPrincipal() {
-            return null;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdFromCookie() {
-            return false;
-        }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        public boolean isRequestedSessionIdFromUrl() {
-            return false;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdFromURL() {
-            return false;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdValid() {
-            return false;
-        }
-
-        @Override
-        public boolean isUserInRole(String role) {
-            if (this.throwExceptionOnCloned) {
-                throw new UnsupportedOperationException();
-            }
-            return false;
-        }
-
-        @Override
-        public void login(String username, String password) throws ServletException {
-            if (this.throwExceptionOnCloned) {
-                throw new ServletException();
-            }
-        }
-
-        @Override
-        public void logout() throws ServletException {
-            if (this.throwExceptionOnCloned) {
-                throw new ServletException();
-            }
-        }
-
-        @Override
-        public AsyncContext getAsyncContext() {
-            return null;
-        }
-
-        @Override
-        public Object getAttribute(String name) {
-            return null;
-        }
-
-        @Override
-        public Enumeration<String> getAttributeNames() {
-            return EMPTY_ENUM_STRING;
-        }
-
-        @Override
-        public String getCharacterEncoding() {
-            return null;
-        }
-
-        @Override
-        public int getContentLength() {
-            return 0;
-        }
-
-        @Override
-        public long getContentLengthLong() {
-            return 0;
-        }
-
-        @Override
-        public String getContentType() {
-            return "text/plain";
-        }
-
-        @Override
-        public DispatcherType getDispatcherType() {
-            return DispatcherType.REQUEST;
-        }
-
-        @Override
-        public ServletInputStream getInputStream() throws IOException {
-            return voidStream;
-        }
-
-        @Override
-        public Locale getLocale() {
-            return null;
-        }
-
-        @Override
-        public Enumeration<Locale> getLocales() {
-            return EMPTY_ENUM_LOCALE;
-        }
-
-        @Override
-        public String getLocalName() {
-            return null;
-        }
-
-        @Override
-        public int getLocalPort() {
-            return 0;
-        }
-
-        @Override
-        public String getLocalAddr() {
-            return "";
-        }
-
-        @Override
-        public String getParameter(String name) {
-            return "";
-        }
-
-        @Override
-        public Map<String, String[]> getParameterMap() {
-            return EMPTY_MAP_STRING;
-        }
-
-        @Override
-        public Enumeration<String> getParameterNames() {
-            return EMPTY_ENUM_STRING;
-        }
-
-        @Override
-        public String[] getParameterValues(String name) {
-            return EMPTY_ARRAY;
-        }
-
-        @Override
-        public String getProtocol() {
-            return "HTTP/1.1";
-        }
-
-        @Override
-        public BufferedReader getReader() throws IOException {
-            return getVoidReader();
-        }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        public String getRealPath(String path) {
-            return path;
-        }
-
-        @Override
-        public String getRemoteAddr() {
-            return "";
-        }
-
-        @Override
-        public String getRemoteHost() {
-            return "";
-        }
-
-        @Override
-        public int getRemotePort() {
-            return 0;
-        }
-
-        @Override
-        public RequestDispatcher getRequestDispatcher(String path) {
-            return null;
-        }
-
-        @Override
-        public String getScheme() {
-            return "ws";
-        }
-
-        @Override
-        public String getServerName() {
-            return "";
-        }
-
-        @Override
-        public int getServerPort() {
-            return 0;
-        }
-
-        @Override
-        public ServletContext getServletContext() {
-            return null;
-        }
-
-        @Override
-        public boolean isAsyncStarted() {
-            return false;
-        }
-
-        @Override
-        public boolean isAsyncSupported() {
-            return true;
-        }
-
-        @Override
-        public boolean isSecure() {
-            return false;
-        }
-
-        @Override
-        public void removeAttribute(String name) {
-
-        }
-
-        @Override
-        public void setAttribute(String name, Object o) {
-
-        }
-
-        @Override
-        public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
-        }
-
-        @Override
-        public AsyncContext startAsync() {
-            return null;
-        }
-
-        @Override
-        public AsyncContext startAsync(ServletRequest request, ServletResponse response) {
-            return null;
+            super(throwExceptionOnCloned);
         }
     }
 

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceEventImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceEventImpl.java
@@ -129,7 +129,7 @@ public class AtmosphereResourceEventImpl implements AtmosphereResourceEvent {
 
     public AtmosphereResourceEventImpl setCancelled(boolean isCancelled) {
         if (check()) {
-            resource.action().type(Action.TYPE.CANCELLED);
+            resource.setAction(new Action(Action.TYPE.CANCELLED, resource.action().timeout()));
             this.isCancelled.set(isCancelled);
         }
         return this;
@@ -137,7 +137,7 @@ public class AtmosphereResourceEventImpl implements AtmosphereResourceEvent {
 
     protected AtmosphereResourceEventImpl setIsResumedOnTimeout(boolean isResumedOnTimeout) {
         if (check()) {
-            resource.action().type(Action.TYPE.TIMEOUT);
+            resource.setAction(new Action(Action.TYPE.TIMEOUT, resource.action().timeout()));
             this.isResumedOnTimeout.set(isResumedOnTimeout);
         }
         return this;

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResourceImpl.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.atmosphere.cpr.ApplicationConfig.PROPERTY_SESSION_CREATE;
@@ -54,18 +55,35 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
     public static final String PRE_SUSPEND = AtmosphereResourceImpl.class.getName() + ".preSuspend";
     public static final String SKIP_BROADCASTER_CREATION = AtmosphereResourceImpl.class.getName() + ".skipBroadcasterCreation";
 
+    /**
+     * Explicit lifecycle states for an {@link AtmosphereResource}, replacing the previous
+     * collection of independent {@link AtomicBoolean} fields that tracked lifecycle implicitly.
+     */
+    public enum LifecycleState {
+        /** Initial state after construction or {@link #reset()}. */
+        CREATED,
+        /** {@link #suspend()} called successfully. */
+        SUSPENDED,
+        /** {@link #resume()} called successfully. */
+        RESUMED,
+        /** Resource is in the closing phase (entered {@code completeLifecycle}). */
+        CLOSING,
+        /** {@link #cancel()} called successfully. */
+        CANCELLED,
+        /** Resource marked out of scope due to IO error or external invalidation. */
+        DISCONNECTED
+    }
+
     private AtmosphereRequest req;
     private AtmosphereResponse response;
-    private final Action action = new Action();
+    private Action action = new Action();
     protected final List<Broadcaster> broadcasters = new CopyOnWriteArrayList<>();
     protected Broadcaster broadcaster;
     private AtmosphereConfig config;
     protected AsyncSupport<AtmosphereResourceImpl> asyncSupport;
     private Serializer serializer;
-    private final AtomicBoolean isInScope = new AtomicBoolean(true);
+    private final AtomicReference<LifecycleState> state = new AtomicReference<>(LifecycleState.CREATED);
     private AtmosphereResourceEventImpl event;
-    private final AtomicBoolean isResumed = new AtomicBoolean();
-    private final AtomicBoolean isCancelled = new AtomicBoolean();
     private final AtomicBoolean resumeOnBroadcast = new AtomicBoolean();
     private Object writeOnTimeout;
     private boolean disableSuspend;
@@ -81,9 +99,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
     private boolean disableSuspendEvent;
     private TRANSPORT transport;
     private boolean forceBinaryWrite;
-    private final AtomicBoolean suspended = new AtomicBoolean();
     private WebSocket webSocket;
-    private final AtomicBoolean inClosingPhase = new AtomicBoolean();
     private boolean closeOnCancel;
     private final AtomicBoolean isPendingClose = new AtomicBoolean();
     private final ReentrantLock broadcasterRecoveryLock = new ReentrantLock();
@@ -170,24 +186,16 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
             return TRANSPORT.WEBSOCKET;
         }
 
-        s = s.replace("-", "_").toUpperCase();
-        if (TRANSPORT.POLLING.name().equals(s)) {
-            return TRANSPORT.POLLING;
-        } else if (TRANSPORT.LONG_POLLING.name().equals(s)) {
-            return TRANSPORT.LONG_POLLING;
-        } else if (TRANSPORT.STREAMING.name().equals(s)) {
-            return TRANSPORT.STREAMING;
-        } else if (TRANSPORT.WEBSOCKET.name().equals(s)) {
-            return TRANSPORT.WEBSOCKET;
-        } else if (TRANSPORT.SSE.name().equals(s)) {
-            return TRANSPORT.SSE;
-        } else if (TRANSPORT.AJAX.name().equals(s)) {
-            return TRANSPORT.AJAX;
-        } else if (TRANSPORT.CLOSE.name().equals(s)) {
-            return TRANSPORT.CLOSE;
-        } else {
-            return UNDEFINED;
-        }
+        return switch (s.replace("-", "_").toUpperCase()) {
+            case "POLLING" -> TRANSPORT.POLLING;
+            case "LONG_POLLING" -> TRANSPORT.LONG_POLLING;
+            case "STREAMING" -> TRANSPORT.STREAMING;
+            case "WEBSOCKET" -> TRANSPORT.WEBSOCKET;
+            case "SSE" -> TRANSPORT.SSE;
+            case "AJAX" -> TRANSPORT.AJAX;
+            case "CLOSE" -> TRANSPORT.CLOSE;
+            default -> UNDEFINED;
+        };
     }
 
     @Override
@@ -241,7 +249,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
 
     @Override
     public boolean isSuspended() {
-        return suspended.get();
+        return state.get() == LifecycleState.SUSPENDED;
     }
 
     @Override
@@ -268,11 +276,10 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
         }
 
         try {
-            if (!isResumed.getAndSet(true) && isInScope.get()) {
-                suspended.set(false);
+            if (state.compareAndSet(LifecycleState.SUSPENDED, LifecycleState.RESUMED)) {
                 logger.trace("AtmosphereResource {} is resuming", uuid());
 
-                action.type(Action.TYPE.RESUME);
+                action = new Action(Action.TYPE.RESUME, action.timeout());
 
                 boolean notify = true;
                 for (Broadcaster b : broadcasters) {
@@ -353,7 +360,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
         if (event.isSuspended() || disableSuspend) return this;
 
         if (!event.isResumedOnTimeout()) {
-            suspended.set(true);
+            state.set(LifecycleState.SUSPENDED);
 
             Enumeration<String> connection = req.getHeaders("Connection");
             if (connection == null) {
@@ -378,8 +385,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
             }
 
             req.setAttribute(PRE_SUSPEND, "true");
-            action.type(Action.TYPE.SUSPEND);
-            action.timeout(timeout);
+            action = new Action(Action.TYPE.SUSPEND, timeout);
 
             // Optimization opportunity: avoid creating a Broadcaster when the Broadcaster is unique
             boolean isJersey = req.getAttribute(FrameworkConfig.CONTAINER_RESPONSE) != null;
@@ -401,7 +407,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
 
             Objects.requireNonNull(broadcaster).addAtmosphereResource(this);
             if (req.getAttribute(DefaultBroadcaster.CACHED) != null && transport() != null && Utils.resumableTransport(transport())) {
-                action.type(Action.TYPE.CONTINUE);
+                action = new Action(Action.TYPE.CONTINUE, action.timeout());
                 // Do nothing because we have found cached message which was written already, and the handler resumed.
                 logger.debug("Cached message found, not suspending {}", uuid());
                 return this;
@@ -414,14 +420,14 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
     }
 
     public AtmosphereRequest getRequest(boolean enforceScope) {
-        if (enforceScope && !isInScope.get()) {
+        if (enforceScope && !isInScope()) {
             throw new IllegalStateException("Request object no longer" + " valid. This object has been cancelled");
         }
         return req;
     }
 
     public AtmosphereResponse getResponse(boolean enforceScope) {
-        if (enforceScope && !isInScope.get()) {
+        if (enforceScope && !isInScope()) {
             throw new IllegalStateException("Response object no longer valid. This object has been cancelled");
         }
         return response;
@@ -525,25 +531,34 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
         return action;
     }
 
+    public void setAction(Action action) {
+        this.action = action;
+    }
+
     /**
      * Completely reset the instance to its initial state.
      */
     public void reset() {
-        isResumed.set(false);
-        isCancelled.set(false);
+        state.set(LifecycleState.CREATED);
         isPendingClose.set(false);
-        isInScope.set(true);
         isSuspendEvent.set(false);
+        disconnected.set(false);
         listeners.clear();
-        action.type(Action.TYPE.CREATED);
+        action = new Action(Action.TYPE.CREATED, action.timeout());
     }
 
     /**
      * Protect the object from being used after it got cancelled.
      *
-     * */
-    public void setIsInScope(boolean isInScope) {
-        this.isInScope.set(isInScope);
+     * @param inScope when false, transitions the resource to {@link LifecycleState#DISCONNECTED}
+     */
+    public void setIsInScope(boolean inScope) {
+        if (!inScope) {
+            state.set(LifecycleState.DISCONNECTED);
+        } else {
+            // Only valid during reset — transition back to CREATED
+            state.set(LifecycleState.CREATED);
+        }
     }
 
     /**
@@ -552,7 +567,18 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
      * @return true if the {@link AtmosphereRequest} still is valid
      */
     public boolean isInScope() {
-        return isInScope.get();
+        var s = state.get();
+        return s == LifecycleState.CREATED || s == LifecycleState.SUSPENDED
+                || s == LifecycleState.RESUMED || s == LifecycleState.CLOSING;
+    }
+
+    /**
+     * Return the current {@link LifecycleState} of this resource.
+     *
+     * @return the current lifecycle state
+     */
+    public LifecycleState lifecycleState() {
+        return state.get();
     }
 
     /**
@@ -567,12 +593,12 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
 
     @Override
     public boolean isResumed() {
-        return isResumed.get();
+        return state.get() == LifecycleState.RESUMED;
     }
 
     @Override
     public boolean isCancelled() {
-        return isCancelled.get();
+        return state.get() == LifecycleState.CANCELLED;
     }
 
     @Override
@@ -659,7 +685,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
             }
 
             if (previousType != action.type()) {
-                action().type(Action.TYPE.CREATED);
+                action = new Action(Action.TYPE.CREATED, action.timeout());
             }
         } catch (Throwable t) {
             ((AtmosphereResourceEventImpl) event).setThrowable(t);
@@ -789,8 +815,8 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
 
     public void cancel() throws IOException {
         try {
-            if (!isCancelled.getAndSet(true)) {
-                suspended.set(false);
+            var prev = state.getAndSet(LifecycleState.CANCELLED);
+            if (prev != LifecycleState.CANCELLED) {
                 logger.trace("Cancelling {}", uuid());
 
                 if (config.getBroadcasterFactory() != null) {
@@ -805,7 +831,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
                 asyncSupport.complete(this);
 
                 SessionTimeoutSupport.restoreTimeout(req);
-                action.type(Action.TYPE.CANCELLED);
+                action = new Action(Action.TYPE.CANCELLED, action.timeout());
                 if (asyncSupport != null) asyncSupport.action(this);
                 // We must close the underlying WebSocket as well.
                 if (response instanceof AtmosphereResponseImpl) {
@@ -833,7 +859,7 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
 
     public void _destroy() {
         try {
-            if (!isCancelled.get()) {
+            if (state.get() != LifecycleState.CANCELLED) {
                 removeFromAllBroadcasters();
             }
             broadcasters.clear();
@@ -854,7 +880,8 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
             return "AtmosphereResource{" +
                     "\n\t uuid=" + uuid() +
                     ",\n\t transport=" + transport() +
-                    ",\n\t isInScope=" + isInScope +
+                    ",\n\t state=" + state.get() +
+                    ",\n\t isInScope=" + isInScope() +
                     ",\n\t isResumed=" + isResumed() +
                     ",\n\t isCancelled=" + isCancelled() +
                     ",\n\t isSuspended=" + isSuspended() +
@@ -999,17 +1026,30 @@ public class AtmosphereResourceImpl implements AtmosphereResource {
         return uuid() != null ? uuid().hashCode() : 0;
     }
 
+    /**
+     * Atomically transitions to {@link LifecycleState#CLOSING} if not already in that state.
+     *
+     * @return true if the resource was already in the closing phase, false if this call initiated it
+     */
     public boolean getAndSetInClosingPhase() {
-        return inClosingPhase.getAndSet(true);
+        while (true) {
+            var current = state.get();
+            if (current == LifecycleState.CLOSING || current == LifecycleState.CANCELLED) {
+                return true;
+            }
+            if (state.compareAndSet(current, LifecycleState.CLOSING)) {
+                return false;
+            }
+        }
     }
 
     /**
-     * @return
+     * @return true if this resource has a pending delayed close
      */
     public boolean isPendingClose () {
         return isPendingClose.get();
     }
-    
+
     public boolean getAndSetPendingClose() {
         return isPendingClose.getAndSet(true);
     }

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResponse.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResponse.java
@@ -15,15 +15,10 @@
  */
 package org.atmosphere.cpr;
 
-import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.Collection;
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -42,64 +37,7 @@ public interface AtmosphereResponse extends HttpServletResponse {
 
     boolean destroyed();
 
-    @Override
-    void addCookie(Cookie cookie);
-
-    @Override
-    boolean containsHeader(String name);
-
-    @Override
-    String encodeURL(String url);
-
-    @Override
-    String encodeRedirectURL(String url);
-
-    @SuppressWarnings("deprecation")
-    @Override
-    String encodeUrl(String url);
-
-    @SuppressWarnings("deprecation")
-    @Override
-    String encodeRedirectUrl(String url);
-
     AtmosphereResponse delegateToNativeResponse(boolean delegateToNativeResponse);
-
-    @Override
-    void sendError(int sc, String msg) throws IOException;
-
-    @Override
-    void sendError(int sc) throws IOException;
-
-    @Override
-    void sendRedirect(String location) throws IOException;
-
-    @Override
-    void setDateHeader(String name, long date);
-
-    @Override
-    void addDateHeader(String name, long date);
-
-    @Override
-    void setHeader(String name, String value);
-
-    @Override
-    void addHeader(String name, String value);
-
-    @Override
-    void setIntHeader(String name, int value);
-
-    @Override
-    void addIntHeader(String name, int value);
-
-    @Override
-    void setStatus(int status);
-
-    @SuppressWarnings("deprecation")
-    @Override
-    void setStatus(int status, String statusMessage);
-
-    @Override
-    int getStatus();
 
     ServletResponse getResponse();
 
@@ -107,66 +45,12 @@ public interface AtmosphereResponse extends HttpServletResponse {
 
     Map<String, String> headers();
 
-    @Override
-    String getHeader(String name);
-
-    @Override
-    Collection<String> getHeaders(String name);
-
-    @Override
-    Collection<String> getHeaderNames();
-
-    @Override
-    void setCharacterEncoding(String charSet);
-
-    @Override
-    void flushBuffer() throws IOException;
-
-    @Override
-    int getBufferSize();
-
-    @Override
-    String getCharacterEncoding();
-
     /**
      * Check if this object can be destroyed. Default is true.
      */
     boolean isDestroyable();
 
     AtmosphereResponse destroyable(boolean destroyable);
-
-    @Override
-    ServletOutputStream getOutputStream() throws IOException;
-
-    @Override
-    PrintWriter getWriter() throws IOException;
-
-    @Override
-    void setContentLength(int len);
-
-    @Override
-    void setContentType(String contentType);
-
-    @Override
-    String getContentType();
-
-    @Override
-    boolean isCommitted();
-
-    @Override
-    void reset();
-
-    @Override
-    void resetBuffer();
-
-    @Override
-    void setBufferSize(int size);
-
-    @Override
-    void setLocale(Locale locale);
-
-    @Override
-    Locale getLocale();
 
     /**
      * Return the underlying {@link AsyncIOWriter}.
@@ -281,9 +165,6 @@ public interface AtmosphereResponse extends HttpServletResponse {
      * @return the {@link AtmosphereResource#uuid()} used by this object.
      */
     String uuid();
-
-    @Override
-    String toString();
 
     interface Builder {
         Builder destroyable(boolean isRecyclable);

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResponseImpl.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/AtmosphereResponseImpl.java
@@ -17,21 +17,17 @@ package org.atmosphere.cpr;
 
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.ServletResponse;
-import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
 import org.atmosphere.util.CookieUtil;
-import org.atmosphere.util.HtmlEncoder;
 import org.atmosphere.util.ServletProxyFactory;
 import org.atmosphere.websocket.WebSocket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,9 +39,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
-import static org.atmosphere.cpr.ApplicationConfig.PROPERTY_USE_STREAM;
 import static org.atmosphere.cpr.ApplicationConfig.RECYCLE_ATMOSPHERE_REQUEST_RESPONSE;
 
 /**
@@ -71,11 +65,10 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
     }
 
     private final static Logger logger = LoggerFactory.getLogger(AtmosphereResponseImpl.class);
-    private final static ThreadLocal<Object> NO_BUFFERING = new ThreadLocal<>();
 
+    // -- Response metadata (state) --
     private final List<Cookie> cookies = new ArrayList<>();
     private final Map<String, String> headers;
-    private AsyncIOWriter asyncIOWriter;
     private int status = 200;
     private String statusMessage = "OK";
     private String charSet = "UTF-8";
@@ -84,56 +77,54 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
     private boolean isCommited;
     private Locale locale;
     private boolean headerHandled;
+    private String uuid = "0";
+    private boolean destroyable;
+    private final AtomicBoolean destroyed = new AtomicBoolean(false);
+
+    // -- Request association --
     private AtmosphereRequest atmosphereRequest;
+
+    // -- Native response delegate --
     @SuppressWarnings("rawtypes")
     private static final HttpServletResponse dsr = (HttpServletResponse)
             Proxy.newProxyInstance(AtmosphereResponseImpl.class.getClassLoader(), new Class[]{HttpServletResponse.class},
                     (proxy, method, args) -> ServletProxyFactory.getDefault().proxy(proxy, method, args));
-    private final AtomicBoolean writeStatusAndHeader = new AtomicBoolean(false);
-    private boolean delegateToNativeResponse;
-    private boolean destroyable;
     private HttpServletResponse response;
-    private boolean forceAsyncIOWriter;
-    private String uuid = "0";
-    private final AtomicBoolean usingStream = new AtomicBoolean(true);
-    private final AtomicBoolean destroyed = new AtomicBoolean(false);
-    private final AtomicReference<Object> buffered = new AtomicReference<Object>(null);
-    private boolean completed;
+
+    // -- Writer/IO delegation (extracted to ResponseWriter) --
+    private final ResponseWriter writer;
 
     public AtmosphereResponseImpl(AsyncIOWriter asyncIOWriter, AtmosphereRequest atmosphereRequest, boolean destroyable) {
         super(dsr);
         response = dsr;
-        this.asyncIOWriter = asyncIOWriter;
         this.atmosphereRequest = atmosphereRequest;
-        this.writeStatusAndHeader.set(false);
         this.headers = new HashMap<>();
-        this.delegateToNativeResponse = asyncIOWriter == null;
         this.destroyable = destroyable;
+        this.writer = new ResponseWriter(asyncIOWriter, false);
+        this.writer.setContentTypeForSanitization(contentType);
     }
 
     public AtmosphereResponseImpl(HttpServletResponse r, AsyncIOWriter asyncIOWriter, AtmosphereRequest atmosphereRequest, boolean destroyable) {
         super(r);
         response = r;
-        this.asyncIOWriter = asyncIOWriter;
         this.atmosphereRequest = atmosphereRequest;
-        this.writeStatusAndHeader.set(false);
         this.headers = new HashMap<>();
-        this.delegateToNativeResponse = asyncIOWriter == null;
         this.destroyable = destroyable;
+        this.writer = new ResponseWriter(asyncIOWriter, false);
+        this.writer.setContentTypeForSanitization(contentType);
     }
 
     private AtmosphereResponseImpl(Builder b) {
         super(b.atmosphereResponse);
 
         response = b.atmosphereResponse;
-        this.asyncIOWriter = b.asyncIOWriter;
         this.atmosphereRequest = b.atmosphereRequest;
         this.status = b.status;
         this.statusMessage = b.statusMessage;
-        this.writeStatusAndHeader.set(b.writeStatusAndHeader.get());
         this.headers = b.headers;
-        this.delegateToNativeResponse = asyncIOWriter == null;
         this.destroyable = b.destroyable;
+        this.writer = new ResponseWriter(b.asyncIOWriter, b.writeStatusAndHeader.get());
+        this.writer.setContentTypeForSanitization(contentType);
     }
 
     public final static class Builder implements AtmosphereResponse.Builder {
@@ -207,6 +198,13 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
         return response;
     }
 
+    /**
+     * Package-private accessor for the content length value, used by {@link ResponseWriter}.
+     */
+    long contentLengthValue() {
+        return contentLength;
+    }
+
     @Override
     public void destroy() {
         destroy(destroyable);
@@ -219,7 +217,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
         cookies.clear();
         headers.clear();
         atmosphereRequest = null;
-        asyncIOWriter = null;
+        writer.destroy();
         destroyed.set(true);
     }
 
@@ -233,7 +231,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
         if (atmosphereRequest != null && atmosphereRequest.isSecure()) {
             cookie.setSecure(true);
         }
-        if (delegateToNativeResponse) {
+        if (writer.isDelegateToNativeResponse()) {
             _r().addCookie(cookie);
         } else {
             cookies.add(cookie);
@@ -242,7 +240,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public boolean containsHeader(String name) {
-        return !delegateToNativeResponse ? (headers.get(name) != null) : _r().containsHeader(name);
+        return !writer.isDelegateToNativeResponse() ? (headers.get(name) != null) : _r().containsHeader(name);
     }
 
     @Override
@@ -269,65 +267,28 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public AtmosphereResponse delegateToNativeResponse(boolean delegateToNativeResponse) {
-        this.delegateToNativeResponse = delegateToNativeResponse;
+        writer.setDelegateToNativeResponse(delegateToNativeResponse);
         return this;
     }
 
     @Override
     public void sendError(int sc, String msg) throws IOException {
-        if (forceAsyncIOWriter || !delegateToNativeResponse) {
-            setStatus(sc);
-            this.statusMessage = msg;
-
-            // Prevent StackOverflow
-            boolean b = forceAsyncIOWriter;
-            forceAsyncIOWriter = false;
-            asyncIOWriter.writeError(this, sc, msg);
-            forceAsyncIOWriter = b;
-        } else {
-            if (!_r().isCommitted()) {
-                _r().sendError(sc, msg);
-            } else {
-                logger.warn("Committed error code {} {}", sc, msg);
-            }
-        }
+        writer.sendError(this, _r(), sc, msg);
     }
 
     @Override
     public void sendError(int sc) throws IOException {
-        if (forceAsyncIOWriter || !delegateToNativeResponse) {
-            setStatus(sc);
-            // Prevent StackOverflow
-            boolean b = forceAsyncIOWriter;
-            forceAsyncIOWriter = false;
-            asyncIOWriter.writeError(this, sc, "");
-            forceAsyncIOWriter = b;
-        } else {
-            if (!_r().isCommitted()) {
-                _r().sendError(sc);
-            } else {
-                logger.warn("Committed error code {}", sc);
-            }
-        }
+        writer.sendErrorNoMessage(this, _r(), sc);
     }
 
     @Override
     public void sendRedirect(String location) throws IOException {
-        if (forceAsyncIOWriter || !delegateToNativeResponse) {
-
-            // Prevent StackOverflow
-            boolean b = forceAsyncIOWriter;
-            forceAsyncIOWriter = false;
-            asyncIOWriter.redirect(this, location);
-            forceAsyncIOWriter = b;
-        } else {
-            _r().sendRedirect(location);
-        }
+        writer.sendRedirect(this, _r(), location);
     }
 
     @Override
     public void setDateHeader(String name, long date) {
-        if (!delegateToNativeResponse) {
+        if (!writer.isDelegateToNativeResponse()) {
             headers.put(name, String.valueOf(date));
         } else {
             _r().setDateHeader(name, date);
@@ -336,7 +297,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public void addDateHeader(String name, long date) {
-        if (!delegateToNativeResponse) {
+        if (!writer.isDelegateToNativeResponse()) {
             headers.put(name, String.valueOf(date));
         } else {
             _r().setDateHeader(name, date);
@@ -348,7 +309,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
         if (value == null) headers.remove(name);
         else headers.put(name, value);
 
-        if (delegateToNativeResponse) {
+        if (writer.isDelegateToNativeResponse()) {
             _r().setHeader(name, value);
         }
 
@@ -361,7 +322,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
     public void addHeader(String name, String value) {
         headers.put(name, value);
 
-        if (delegateToNativeResponse) {
+        if (writer.isDelegateToNativeResponse()) {
             _r().addHeader(name, value);
         }
     }
@@ -378,9 +339,8 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public void setStatus(int status) {
-        if (!delegateToNativeResponse) {
-            this.status = status;
-        } else {
+        this.status = status;
+        if (writer.isDelegateToNativeResponse()) {
             _r().setStatus(status);
         }
     }
@@ -460,7 +420,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
         if (!s.isEmpty()) {
             return Collections.unmodifiableList(s);
         }
-        return null;
+        return Collections.emptyList();
     }
 
     @Override
@@ -484,7 +444,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public void setCharacterEncoding(String charSet) {
-        if (!delegateToNativeResponse) {
+        if (!writer.isDelegateToNativeResponse()) {
             this.charSet = charSet;
         } else {
             _r().setCharacterEncoding(charSet);
@@ -497,9 +457,9 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
             response.flushBuffer();
         } catch (NullPointerException ex) {
             //https://github.com/Atmosphere/atmosphere/issues/1943
-            handleException(ex);
+            writer.handleException(this, ex);
         } catch (IOException ex) {
-            handleException(ex);
+            writer.handleException(this, ex);
             throw ex;
         }
     }
@@ -511,7 +471,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public String getCharacterEncoding() {
-        if (!delegateToNativeResponse) {
+        if (!writer.isDelegateToNativeResponse()) {
             return charSet;
         } else {
             return _r().getCharacterEncoding() == null ? charSet : _r().getCharacterEncoding();
@@ -529,86 +489,21 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
         return this;
     }
 
-    private void validAsyncIOWriter() throws IOException {
-        if (asyncIOWriter == null) {
-            logger.trace("{} invalid state", this.hashCode());
-            throw new IOException("AtmosphereResource Cancelled: " + uuid);
-        }
-    }
-
-    private boolean validFlushOrClose() {
-        if (asyncIOWriter == null) {
-            logger.warn("AtmosphereResponse for {} has been closed", uuid);
-            return false;
-        }
-        return true;
-    }
-
     @Override
     public ServletOutputStream getOutputStream() throws IOException {
-        if (forceAsyncIOWriter || !delegateToNativeResponse) {
-            return new Stream(isBuffering());
-        } else {
-            return _r().getOutputStream() != null ? _r().getOutputStream() : new ServletOutputStream() {
-                @Override
-                public boolean isReady() {
-                    return false;
-                }
-
-                @Override
-                public void setWriteListener(WriteListener writeListener) {
-                }
-
-                @Override
-                public void write(int b) {
-                }
-            };
-        }
-    }
-
-    private void writeStatusAndHeaders() throws java.io.IOException {
-        if (writeStatusAndHeader.getAndSet(false) && !forceAsyncIOWriter) {
-            asyncIOWriter.write(this, constructStatusAndHeaders());
-        }
-    }
-
-    private String constructStatusAndHeaders() {
-        var b = new StringBuilder("HTTP/1.1")
-                .append(" ")
-                .append(status)
-                .append(" ")
-                .append(statusMessage)
-                .append("\r\n");
-
-        b.append("Content-Type").append(":").append(headers.get("Content-Type") == null ? contentType : headers.get("Content-Type")).append("\r\n");
-        if (contentLength != -1) {
-            b.append("Content-Length").append(":").append(contentLength).append("\r\n");
-        }
-
-        for (String s : headers().keySet()) {
-            if (!s.equalsIgnoreCase("Content-Type")) {
-                b.append(s).append(":").append(headers.get(s)).append("\r\n");
-            }
-        }
-        b.deleteCharAt(b.length() - 2);
-        b.append("\r\n\r\n");
-        return b.toString();
+        return writer.createOutputStream(this, _r());
     }
 
     @Override
     public PrintWriter getWriter() throws IOException {
-        if (forceAsyncIOWriter || !delegateToNativeResponse) {
-            return new Writer(new Stream(isBuffering()));
-        } else {
-            return _r().getWriter() != null ? _r().getWriter() : new PrintWriter(new StringWriter());
-        }
+        return writer.createWriter(this, _r());
     }
 
     @Override
     public void setContentLength(int len) {
         headers.put("Content-Length", String.valueOf(len));
 
-        if (!delegateToNativeResponse) {
+        if (!writer.isDelegateToNativeResponse()) {
             contentLength = len;
         } else {
             _r().setContentLength(len);
@@ -619,11 +514,12 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
     public void setContentType(String contentType) {
         headers.put("Content-Type", String.valueOf(contentType));
 
-        if (!delegateToNativeResponse) {
+        if (!writer.isDelegateToNativeResponse()) {
             this.contentType = contentType;
         } else {
             _r().setContentType(contentType);
         }
+        writer.setContentTypeForSanitization(contentType);
     }
 
     @Override
@@ -633,7 +529,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public boolean isCommitted() {
-        if (!delegateToNativeResponse) {
+        if (!writer.isDelegateToNativeResponse()) {
             return isCommited;
         } else {
             return _r().isCommitted();
@@ -657,7 +553,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public void setLocale(Locale locale) {
-        if (!delegateToNativeResponse) {
+        if (!writer.isDelegateToNativeResponse()) {
             this.locale = locale;
         } else {
             _r().setLocale(locale);
@@ -666,7 +562,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public Locale getLocale() {
-        if (!delegateToNativeResponse) {
+        if (!writer.isDelegateToNativeResponse()) {
             return locale;
         } else {
             return _r().getLocale();
@@ -675,13 +571,12 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public AsyncIOWriter getAsyncIOWriter() {
-        return asyncIOWriter;
+        return writer.getAsyncIOWriter();
     }
 
     @Override
     public AtmosphereResponse asyncIOWriter(AsyncIOWriter asyncIOWriter) {
-        this.asyncIOWriter = asyncIOWriter;
-        forceAsyncIOWriter = true;
+        writer.setAsyncIOWriter(asyncIOWriter);
         return this;
     }
 
@@ -698,25 +593,12 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public void close() throws IOException {
-        if (asyncIOWriter != null) {
-            asyncIOWriter.close(this);
-        }
+        writer.close(this);
     }
 
     @Override
     public void closeStreamOrWriter() {
-        if (resource() != null) {
-            try {
-                if (isUsingStream()) {
-                    getOutputStream().close();
-                } else {
-                    getWriter().close();
-                }
-            } catch (Exception e) {
-                //https://github.com/Atmosphere/atmosphere/issues/1643
-                logger.trace("Unexpected exception", e);
-            }
-        }
+        writer.closeStreamOrWriter(this);
     }
 
     @Override
@@ -724,81 +606,10 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
         return write(data, false);
     }
 
-    private void handleException(Exception ex) {
-        AtmosphereResource r = resource();
-        if (r != null) {
-            r.notifyListeners(
-                    new AtmosphereResourceEventImpl((AtmosphereResourceImpl) r, true, false));
-            // Don't take any risk and remove it.
-            r.getAtmosphereConfig().resourcesFactory().remove(uuid);
-        }
-        logger.trace("{} unexpected I/O exception {}", uuid, ex);
-    }
-
     @Override
     public AtmosphereResponse write(String data, boolean writeUsingOriginalResponse) {
-
-        if (response instanceof Proxy) {
-            writeUsingOriginalResponse = false;
-        }
-
-        String sanitized = sanitizeForOutput(data);
-        try {
-            if (isUsingStream()) {
-                try {
-                    OutputStream o = writeUsingOriginalResponse ? _r().getOutputStream() : getOutputStream();
-                    o.write(sanitized.getBytes(getCharacterEncoding()));
-                } catch (java.lang.IllegalStateException ex) {
-                    logger.trace("", ex);
-                }
-            } else {
-                PrintWriter w = writeUsingOriginalResponse ? _r().getWriter() : getWriter();
-                w.write(sanitized);
-            }
-        } catch (Exception ex) {
-            handleException(ex);
-            throw new RuntimeException(ex);
-        }
+        writer.writeString(this, _r(), data, writeUsingOriginalResponse);
         return this;
-    }
-
-    private boolean isUsingStream() {
-        if (atmosphereRequest != null) {
-            Object s = atmosphereRequest.getAttribute(PROPERTY_USE_STREAM);
-            if (s != null) {
-                usingStream.set((Boolean) s);
-            }
-        }
-
-        // Property always take first.
-        if (resource() != null) {
-            boolean force = resource().forceBinaryWrite();
-            if (!usingStream.get() && force) {
-                usingStream.set(true);
-            }
-        }
-        return usingStream.get();
-    }
-
-    /**
-     * Sanitize string output to prevent XSS when the response content type is HTML.
-     * For non-HTML content types (JSON, plain text, etc.), data passes through unchanged.
-     * WebSocket frames are consumed by JavaScript, not rendered as HTML, so they are
-     * never sanitized regardless of the content type.
-     */
-    private String sanitizeForOutput(String data) {
-        if (data == null) {
-            return null;
-        }
-        // WebSocket frames are not rendered as HTML by the browser
-        if (asyncIOWriter instanceof WebSocket) {
-            return data;
-        }
-        String ct = contentType;
-        if (ct != null && ct.contains("html")) {
-            return HtmlEncoder.encode(data);
-        }
-        return data;
     }
 
     @Override
@@ -808,32 +619,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public AtmosphereResponse write(byte[] data, boolean writeUsingOriginalResponse) {
-
-        if (data == null) {
-            logger.error("Cannot write null value for {}", resource());
-            return this;
-        }
-
-        if (response instanceof Proxy) {
-            writeUsingOriginalResponse = false;
-        }
-
-        try {
-            if (isUsingStream()) {
-                try {
-                    OutputStream o = writeUsingOriginalResponse ? _r().getOutputStream() : getOutputStream();
-                    o.write(data);
-                } catch (java.lang.IllegalStateException ex) {
-                    logger.trace("", ex);
-                }
-            } else {
-                PrintWriter w = writeUsingOriginalResponse ? _r().getWriter() : getWriter();
-                w.write(sanitizeForOutput(new String(data, getCharacterEncoding())));
-            }
-        } catch (Exception ex) {
-            handleException(ex);
-            throw new RuntimeException(ex);
-        }
+        writer.writeBytes(this, _r(), data, writeUsingOriginalResponse);
         return this;
     }
 
@@ -844,32 +630,7 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
 
     @Override
     public AtmosphereResponse write(byte[] data, int offset, int length, boolean writeUsingOriginalResponse) {
-
-        if (data == null) {
-            logger.error("Cannot write null value for {}", resource());
-            return this;
-        }
-
-        if (response instanceof Proxy) {
-            writeUsingOriginalResponse = false;
-        }
-
-        try {
-            if (isUsingStream()) {
-                try {
-                    OutputStream o = writeUsingOriginalResponse ? _r().getOutputStream() : getOutputStream();
-                    o.write(data, offset, length);
-                } catch (java.lang.IllegalStateException ex) {
-                    logger.trace("", ex);
-                }
-            } else {
-                PrintWriter w = writeUsingOriginalResponse ? _r().getWriter() : getWriter();
-                w.write(sanitizeForOutput(new String(data, offset, length, getCharacterEncoding())));
-            }
-        } catch (Exception ex) {
-            handleException(ex);
-            throw new RuntimeException(ex);
-        }
+        writer.writeBytes(this, _r(), data, offset, length, writeUsingOriginalResponse);
         return this;
     }
 
@@ -937,315 +698,24 @@ public class AtmosphereResponseImpl extends HttpServletResponseWrapper implement
         return "AtmosphereResponse{" +
                 ", uuid=" + uuid +
                 ", headers=" + headers +
-                ", asyncIOWriter=" + asyncIOWriter +
+                ", asyncIOWriter=" + writer.getAsyncIOWriter() +
                 ", status=" + status +
                 ", statusMessage='" + statusMessage + '\'' +
                 ", atmosphereRequest=" + atmosphereRequest +
-                ", writeStatusAndHeader=" + writeStatusAndHeader +
-                ", delegateToNativeResponse=" + delegateToNativeResponse +
+                ", writeStatusAndHeader=" + writer.getWriteStatusAndHeader() +
+                ", delegateToNativeResponse=" + writer.isDelegateToNativeResponse() +
                 ", destroyable=" + destroyable +
                 ", response=" + response +
                 '}';
     }
 
-    private final class Stream extends ServletOutputStream {
-        private final boolean buffering;
-
-        Stream(boolean buffering) {
-            this.buffering = buffering;
-        }
-
-        @Override
-        public void write(int i) throws java.io.IOException {
-            write(new byte[]{(byte) i});
-        }
-
-        @Override
-        public void write(byte[] bytes) throws java.io.IOException {
-            // Prevent StackOverflow
-            boolean b = forceAsyncIOWriter;
-            try {
-                validAsyncIOWriter();
-                writeStatusAndHeaders();
-
-                forceAsyncIOWriter = false;
-                if (buffering && !AtmosphereResponseImpl.this.completed()) {
-                    writeWithBuffering(bytes);
-                } else {
-                    asyncIOWriter.write(AtmosphereResponseImpl.this, bytes);
-                }
-            } catch (IOException e) {
-                handleException(e);
-                throw e;
-            } finally {
-                forceAsyncIOWriter = b;
-            }
-        }
-
-        @Override
-        public void write(byte[] bytes, int start, int offset) throws java.io.IOException {
-            // Prevent StackOverflow
-            boolean b = forceAsyncIOWriter;
-            try {
-                validAsyncIOWriter();
-                writeStatusAndHeaders();
-
-                forceAsyncIOWriter = false;
-                if (buffering && !AtmosphereResponseImpl.this.completed()) {
-                    byte[] copy = new byte[offset];
-                    System.arraycopy(bytes, start, copy, 0, offset);
-                    writeWithBuffering(copy);
-                } else {
-                    asyncIOWriter.write(AtmosphereResponseImpl.this, bytes, start, offset);
-                }
-            } catch (IOException e) {
-                handleException(e);
-                throw e;
-            } finally {
-                forceAsyncIOWriter = b;
-            }
-        }
-
-        @Override
-        public void flush() throws IOException {
-            if (!validFlushOrClose()) return;
-
-            writeStatusAndHeaders();
-
-            // Prevent StackOverflow
-            boolean b = forceAsyncIOWriter;
-            forceAsyncIOWriter = false;
-            try {
-                asyncIOWriter.flush(AtmosphereResponseImpl.this);
-            } catch (IOException e) {
-                handleException(e);
-                throw e;
-            } finally {
-                forceAsyncIOWriter = b;
-            }
-        }
-
-        @Override
-        public void close() throws java.io.IOException {
-            AtmosphereResponseImpl.this.onComplete();
-            if (!validFlushOrClose()
-                    || asyncIOWriter instanceof KeepOpenStreamAware) return;
-
-            // Prevent StackOverflow
-            boolean b = forceAsyncIOWriter;
-            forceAsyncIOWriter = false;
-            try {
-                if (buffering && !AtmosphereResponseImpl.this.completed()) {
-                    writeWithBuffering(null);
-                }
-                asyncIOWriter.close(AtmosphereResponseImpl.this);
-            } catch (IOException e) {
-                handleException(e);
-                throw e;
-            } finally {
-                forceAsyncIOWriter = b;
-            }
-        }
-
-        @Override
-        public boolean isReady() {
-            return false;
-        }
-
-        @Override
-        public void setWriteListener(WriteListener writeListener) {
-        }
-    }
-
-    private final class Writer extends PrintWriter {
-        public Writer(OutputStream out) {
-            super(out);
-        }
-
-        @Override
-        public void write(char[] chars, int offset, int lenght) {
-            boolean b = forceAsyncIOWriter;
-            try {
-                validAsyncIOWriter();
-
-                // Prevent StackOverflow
-                writeStatusAndHeaders();
-                forceAsyncIOWriter = false;
-                asyncIOWriter.write(AtmosphereResponseImpl.this, new String(chars, offset, lenght));
-            } catch (IOException e) {
-                handleException(e);
-                throw new RuntimeException(e);
-            } finally {
-                forceAsyncIOWriter = b;
-            }
-        }
-
-        @Override
-        public void write(char[] chars) {
-            boolean b = forceAsyncIOWriter;
-            try {
-                validAsyncIOWriter();
-
-                writeStatusAndHeaders();
-                // Prevent StackOverflow
-                forceAsyncIOWriter = false;
-                asyncIOWriter.write(AtmosphereResponseImpl.this, new String(chars));
-            } catch (IOException e) {
-                handleException(e);
-                throw new RuntimeException(e);
-            } finally {
-                forceAsyncIOWriter = b;
-            }
-        }
-
-        @Override
-        public void write(String s, int offset, int lenght) {
-            boolean b = forceAsyncIOWriter;
-
-            try {
-                validAsyncIOWriter();
-
-                writeStatusAndHeaders();
-                // Prevent StackOverflow
-                forceAsyncIOWriter = false;
-                asyncIOWriter.write(AtmosphereResponseImpl.this, s.substring(offset, lenght));
-            } catch (IOException e) {
-                handleException(e);
-                throw new RuntimeException(e);
-            } finally {
-                forceAsyncIOWriter = b;
-            }
-        }
-
-        @Override
-        public void write(String s) {
-
-            boolean b = forceAsyncIOWriter;
-            try {
-                validAsyncIOWriter();
-
-                writeStatusAndHeaders();
-                // Prevent StackOverflow
-                forceAsyncIOWriter = false;
-                asyncIOWriter.write(AtmosphereResponseImpl.this, s);
-            } catch (IOException e) {
-                handleException(e);
-                throw new RuntimeException(e);
-            } finally {
-                forceAsyncIOWriter = b;
-            }
-        }
-
-        @Override
-        public void flush() {
-            if (!validFlushOrClose()) return;
-
-            boolean b = forceAsyncIOWriter;
-            try {
-                writeStatusAndHeaders();
-                // Prevent StackOverflow
-                forceAsyncIOWriter = false;
-                asyncIOWriter.flush(AtmosphereResponseImpl.this);
-            } catch (IOException e) {
-                handleException(e);
-            } finally {
-                forceAsyncIOWriter = b;
-            }
-        }
-
-        @Override
-        public void close() {
-            if (!validFlushOrClose()
-                    || asyncIOWriter instanceof KeepOpenStreamAware) return;
-
-            // Prevent StackOverflow
-            boolean b = forceAsyncIOWriter;
-            forceAsyncIOWriter = false;
-            try {
-                asyncIOWriter.close(AtmosphereResponseImpl.this);
-            } catch (IOException e) {
-                handleException(e);
-            } finally {
-                forceAsyncIOWriter = b;
-            }
-        }
-    }
-
-    private boolean isCompletionReset() {
-        return atmosphereRequest != null
-                && Boolean.TRUE == atmosphereRequest.getAttribute(ApplicationConfig.RESPONSE_COMPLETION_RESET);
-    }
-
     @Override
     public void onComplete() {
-        if (!completed) {
-            completed = true;
-            try {
-                writeWithBuffering(null);
-            } catch (IOException e) {
-                // ignore as the exception is already handled
-            } finally {
-                //reset the completion status for the subsequent push writes
-                if (isCompletionReset()) {
-                    completed = false;
-                }
-            }
-        }
+        writer.onComplete(this);
     }
 
     @Override
     public boolean completed() {
-        return completed;
-    }
-
-    /**
-     * Caches the specified data and writes the previous data if it is not null.
-     *
-     */
-    private void writeWithBuffering(Object data) throws java.io.IOException {
-        if (NO_BUFFERING.get() != null) {
-            boolean b = forceAsyncIOWriter;
-            try {
-                if (data instanceof String s) {
-                    asyncIOWriter.write(AtmosphereResponseImpl.this, s);
-                } else if (data instanceof byte[] bytes) {
-                    asyncIOWriter.write(AtmosphereResponseImpl.this, bytes);
-                }
-            } catch (IOException e) {
-                handleException(e);
-                throw e;
-            } finally {
-                forceAsyncIOWriter = b;
-            }
-        } else {
-            try {
-                NO_BUFFERING.set(Boolean.TRUE);
-                Object previous = buffered.getAndSet(data);
-                if (previous != null) {
-                    boolean b = forceAsyncIOWriter;
-                    try {
-                        if (previous instanceof String s) {
-                            asyncIOWriter.write(AtmosphereResponseImpl.this, s);
-                        } else if (previous instanceof byte[] bytes) {
-                            asyncIOWriter.write(AtmosphereResponseImpl.this, bytes);
-                        }
-                    } catch (IOException e) {
-                        handleException(e);
-                        throw e;
-                    } finally {
-                        forceAsyncIOWriter = b;
-                    }
-                }
-
-            } finally {
-                NO_BUFFERING.remove();
-            }
-        }
-
-    }
-
-    private boolean isBuffering() {
-        return atmosphereRequest != null
-                && Boolean.TRUE == atmosphereRequest.getAttribute(ApplicationConfig.RESPONSE_COMPLETION_AWARE);
+        return writer.completed();
     }
 }

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterLifecycle.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterLifecycle.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2008-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.cpr;
+
+import org.atmosphere.lifecycle.LifecycleHandler;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.atmosphere.cpr.BroadcasterLifeCyclePolicy.ATMOSPHERE_RESOURCE_POLICY.NEVER;
+
+/**
+ * Encapsulates the lifecycle management concern for a {@link DefaultBroadcaster}.
+ * <p>
+ * Manages lifecycle policy, lifecycle policy listeners, the lifecycle handler,
+ * and the scheduled lifecycle task reference. Extracted from {@link DefaultBroadcaster}
+ * to separate lifecycle management from the message dispatch hot path.
+ *
+ * @author Jeanfrancois Arcand
+ */
+public class BroadcasterLifecycle {
+
+    private BroadcasterLifeCyclePolicy lifeCyclePolicy = new BroadcasterLifeCyclePolicy.Builder()
+            .policy(NEVER).build();
+
+    private final ConcurrentLinkedQueue<BroadcasterLifeCyclePolicyListener> lifeCycleListeners =
+            new ConcurrentLinkedQueue<>();
+
+    private final AtomicBoolean recentActivity = new AtomicBoolean(false);
+
+    private LifecycleHandler lifecycleHandler;
+
+    private Future<?> currentLifecycleTask;
+
+    /**
+     * Return the current {@link BroadcasterLifeCyclePolicy}.
+     *
+     * @return the lifecycle policy
+     */
+    public BroadcasterLifeCyclePolicy policy() {
+        return lifeCyclePolicy;
+    }
+
+    /**
+     * Set the {@link BroadcasterLifeCyclePolicy} and activate the lifecycle handler if one is set.
+     *
+     * @param policy the new lifecycle policy
+     * @param broadcaster the broadcaster to apply the policy on
+     */
+    public void setPolicy(BroadcasterLifeCyclePolicy policy, DefaultBroadcaster broadcaster) {
+        this.lifeCyclePolicy = policy;
+        if (lifecycleHandler != null) {
+            lifecycleHandler.on(broadcaster);
+        }
+    }
+
+    /**
+     * Add a {@link BroadcasterLifeCyclePolicyListener}.
+     *
+     * @param listener the listener to add
+     */
+    public void addLifeCycleListener(BroadcasterLifeCyclePolicyListener listener) {
+        lifeCycleListeners.add(listener);
+    }
+
+    /**
+     * Remove a {@link BroadcasterLifeCyclePolicyListener}.
+     *
+     * @param listener the listener to remove
+     */
+    public void removeLifeCycleListener(BroadcasterLifeCyclePolicyListener listener) {
+        lifeCycleListeners.remove(listener);
+    }
+
+    /**
+     * Return the lifecycle policy listeners.
+     *
+     * @return the concurrent queue of lifecycle listeners
+     */
+    public ConcurrentLinkedQueue<BroadcasterLifeCyclePolicyListener> lifeCycleListeners() {
+        return lifeCycleListeners;
+    }
+
+    /**
+     * Return the {@link AtomicBoolean} tracking recent activity.
+     *
+     * @return the recent activity flag
+     */
+    public AtomicBoolean recentActivity() {
+        return recentActivity;
+    }
+
+    /**
+     * Return the current {@link LifecycleHandler}.
+     *
+     * @return the lifecycle handler, may be null
+     */
+    public LifecycleHandler lifecycleHandler() {
+        return lifecycleHandler;
+    }
+
+    /**
+     * Set the {@link LifecycleHandler}.
+     *
+     * @param handler the lifecycle handler
+     */
+    public void lifecycleHandler(LifecycleHandler handler) {
+        this.lifecycleHandler = handler;
+    }
+
+    /**
+     * Return the current scheduled lifecycle task.
+     *
+     * @return the lifecycle task future, may be null
+     */
+    public Future<?> currentLifecycleTask() {
+        return currentLifecycleTask;
+    }
+
+    /**
+     * Set the current scheduled lifecycle task.
+     *
+     * @param task the lifecycle task future
+     */
+    public void currentLifecycleTask(Future<?> task) {
+        this.currentLifecycleTask = task;
+    }
+
+    /**
+     * Clear all lifecycle listeners. Called during broadcaster destruction.
+     */
+    public void clearListeners() {
+        lifeCycleListeners.clear();
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterMembership.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/BroadcasterMembership.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2008-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.cpr;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Encapsulates the resource membership concern for a {@link DefaultBroadcaster}.
+ * <p>
+ * Manages the collection of {@link AtmosphereResource} instances subscribed to a broadcaster,
+ * providing thread-safe add, remove, and query operations. Extracted from {@link DefaultBroadcaster}
+ * to separate membership management from the message dispatch hot path.
+ *
+ * @author Jeanfrancois Arcand
+ */
+public class BroadcasterMembership {
+
+    private final ConcurrentLinkedQueue<AtmosphereResource> resources = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Add an {@link AtmosphereResource} to the membership.
+     *
+     * @param r the resource to add
+     */
+    public void add(AtmosphereResource r) {
+        resources.add(r);
+    }
+
+    /**
+     * Remove an {@link AtmosphereResource} from the membership.
+     *
+     * @param r the resource to remove
+     * @return true if the resource was removed
+     */
+    public boolean remove(AtmosphereResource r) {
+        return resources.remove(r);
+    }
+
+    /**
+     * Check if the membership contains the given {@link AtmosphereResource}.
+     *
+     * @param r the resource to check
+     * @return true if the resource is a member
+     */
+    public boolean contains(AtmosphereResource r) {
+        return resources.contains(r);
+    }
+
+    /**
+     * Return true if there are no members.
+     *
+     * @return true if empty
+     */
+    public boolean isEmpty() {
+        return resources.isEmpty();
+    }
+
+    /**
+     * Return the number of members.
+     *
+     * @return the size
+     */
+    public int size() {
+        return resources.size();
+    }
+
+    /**
+     * Clear all members.
+     */
+    public void clear() {
+        resources.clear();
+    }
+
+    /**
+     * Poll the first resource (used for FIFO policy enforcement).
+     *
+     * @return the first resource, or null if empty
+     */
+    public AtmosphereResource poll() {
+        return resources.poll();
+    }
+
+    /**
+     * Return an iterator over the resources.
+     *
+     * @return an iterator
+     */
+    public Iterator<AtmosphereResource> iterator() {
+        return resources.iterator();
+    }
+
+    /**
+     * Return an unmodifiable view of the resources collection.
+     *
+     * @return an unmodifiable collection
+     */
+    public Collection<AtmosphereResource> getResources() {
+        return Collections.unmodifiableCollection(resources);
+    }
+
+    /**
+     * Return the underlying concurrent queue. This provides direct access for the
+     * dispatch hot path and for subclasses that need to iterate over resources.
+     *
+     * @return the underlying queue
+     */
+    public ConcurrentLinkedQueue<AtmosphereResource> queue() {
+        return resources;
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/ByteArrayServletInputStream.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/ByteArrayServletInputStream.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2008-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.cpr;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+/**
+ * A {@link ServletInputStream} backed by a byte array.
+ * <p>
+ * This class was originally the inner class {@code ByteInputStream} in {@link AtmosphereRequestImpl}.
+ *
+ * @author Jeanfrancois Arcand
+ */
+final class ByteArrayServletInputStream extends ServletInputStream {
+
+    private final ByteArrayInputStream bis;
+
+    ByteArrayServletInputStream(byte[] data, int offset, int length) {
+        this.bis = new ByteArrayInputStream(data, offset, length);
+    }
+
+    @Override
+    public int read() throws IOException {
+        return bis.read();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+    @Override
+    public boolean isReady() {
+        return false;
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/ContainerPatcher.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/ContainerPatcher.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2008-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.cpr;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Isolates JVM-global system property mutations that work around container-specific issues.
+ * <p>
+ * During initialization, Atmosphere may need to set system properties to disable strict
+ * compliance modes in certain servlet containers. This class centralizes that logic so it
+ * can be clearly documented, logged, and optionally disabled via
+ * {@link ApplicationConfig#DISABLE_CONTAINER_PATCHING}.
+ * <p>
+ * <strong>Properties modified:</strong>
+ * <ul>
+ *     <li>{@code org.apache.catalina.STRICT_SERVLET_COMPLIANCE} &mdash; set to {@code "false"}
+ *     to prevent Tomcat from enforcing strict servlet spec compliance, which can interfere
+ *     with Atmosphere's async/comet handling.</li>
+ * </ul>
+ *
+ * @author Jeanfrancois Arcand
+ */
+final class ContainerPatcher {
+
+    private static final Logger logger = LoggerFactory.getLogger(ContainerPatcher.class);
+
+    /**
+     * Tomcat system property that controls strict servlet specification compliance.
+     * When enabled, Tomcat enforces stricter request/response behavior that can break
+     * Atmosphere's async processing model.
+     */
+    static final String TOMCAT_STRICT_SERVLET_COMPLIANCE =
+            "org.apache.catalina.STRICT_SERVLET_COMPLIANCE";
+
+    private ContainerPatcher() {
+        // utility class
+    }
+
+    /**
+     * Apply container-specific system property patches unless disabled via init-param.
+     * <p>
+     * If the init-param {@link ApplicationConfig#DISABLE_CONTAINER_PATCHING} is set to
+     * {@code "true"}, no system properties will be modified.
+     * <p>
+     * If a system property is already set to the desired value, it is left untouched
+     * and no log message is emitted for that property.
+     *
+     * @param framework the AtmosphereFramework whose init-params are consulted
+     */
+    static void patch(AtmosphereFramework framework) {
+        if (isDisabled(framework)) {
+            logger.debug("Container patching disabled via {}",
+                    ApplicationConfig.DISABLE_CONTAINER_PATCHING);
+            return;
+        }
+
+        setPropertyIfAbsent(TOMCAT_STRICT_SERVLET_COMPLIANCE, "false");
+    }
+
+    private static boolean isDisabled(AtmosphereFramework framework) {
+        var value = framework.initParams.get(ApplicationConfig.DISABLE_CONTAINER_PATCHING);
+        return Boolean.parseBoolean(value);
+    }
+
+    /**
+     * Sets a system property only if it is not already set to the desired value.
+     * Logs the modification at info level so operators can see what was changed.
+     */
+    private static void setPropertyIfAbsent(String key, String desiredValue) {
+        var currentValue = System.getProperty(key);
+        if (desiredValue.equals(currentValue)) {
+            return;
+        }
+
+        if (currentValue != null) {
+            logger.info("Overwriting system property {} from '{}' to '{}'",
+                    key, currentValue, desiredValue);
+        } else {
+            logger.info("Setting system property {} to '{}'", key, desiredValue);
+        }
+
+        System.setProperty(key, desiredValue);
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAnnotationProcessor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultAnnotationProcessor.java
@@ -16,29 +16,6 @@
 package org.atmosphere.cpr;
 
 import org.atmosphere.config.AtmosphereAnnotation;
-import org.atmosphere.config.service.AsyncSupportListenerService;
-import org.atmosphere.config.service.AsyncSupportService;
-import org.atmosphere.config.service.AtmosphereFrameworkListenerService;
-import org.atmosphere.config.service.AtmosphereHandlerService;
-import org.atmosphere.config.service.AtmosphereInterceptorService;
-import org.atmosphere.config.service.AtmosphereResourceFactoryService;
-import org.atmosphere.config.service.AtmosphereResourceListenerService;
-import org.atmosphere.config.service.AtmosphereService;
-import org.atmosphere.config.service.BroadcasterCacheInspectorService;
-import org.atmosphere.config.service.BroadcasterCacheListenerService;
-import org.atmosphere.config.service.BroadcasterCacheService;
-import org.atmosphere.config.service.BroadcasterFactoryService;
-import org.atmosphere.config.service.BroadcasterFilterService;
-import org.atmosphere.config.service.BroadcasterListenerService;
-import org.atmosphere.config.service.BroadcasterService;
-import org.atmosphere.config.service.EndpointMapperService;
-import org.atmosphere.config.service.ManagedService;
-import org.atmosphere.config.service.RoomService;
-import org.atmosphere.config.service.UUIDProviderService;
-import org.atmosphere.config.service.WebSocketFactoryService;
-import org.atmosphere.config.service.WebSocketHandlerService;
-import org.atmosphere.config.service.WebSocketProcessorService;
-import org.atmosphere.config.service.WebSocketProtocolService;
 import org.atmosphere.util.IOUtils;
 import org.atmosphere.util.annotation.AnnotationDetector;
 import org.slf4j.Logger;
@@ -73,33 +50,9 @@ public class DefaultAnnotationProcessor implements AnnotationProcessor {
      */
     public static final String ANNOTATION_ATTRIBUTE = "org.atmosphere.cpr.ANNOTATION_MAP";
 
-    // Annotation in java is broken.
-    private static final Class<?>[] coreAnnotations = {
-            AtmosphereHandlerService.class,
-            BroadcasterCacheService.class,
-            BroadcasterFilterService.class,
-            BroadcasterFactoryService.class,
-            BroadcasterService.class,
-            WebSocketFactoryService.class,
-            WebSocketHandlerService.class,
-            WebSocketProtocolService.class,
-            AtmosphereInterceptorService.class,
-            BroadcasterListenerService.class,
-            AsyncSupportService.class,
-            AsyncSupportListenerService.class,
-            WebSocketProcessorService.class,
-            BroadcasterCacheInspectorService.class,
-            ManagedService.class,
-            AtmosphereService.class,
-            EndpointMapperService.class,
-            BroadcasterCacheListenerService.class,
-            AtmosphereAnnotation.class,
-            AtmosphereResourceFactoryService.class,
-            AtmosphereFrameworkListenerService.class,
-            AtmosphereResourceListenerService.class,
-            UUIDProviderService.class,
-            RoomService.class
-    };
+    // Source of truth: AtmosphereAnnotations.coreAnnotations()
+    private static final List<Class<? extends Annotation>> coreAnnotations =
+            AtmosphereAnnotations.coreAnnotations();
 
     private AnnotationProcessor delegate;
     private final AnnotationHandler handler;

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/DefaultBroadcaster.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -60,8 +59,8 @@ import static org.atmosphere.cpr.ApplicationConfig.MAX_INACTIVE;
 import static org.atmosphere.cpr.ApplicationConfig.OUT_OF_ORDER_BROADCAST;
 import static org.atmosphere.cpr.ApplicationConfig.SUSPENDED_ATMOSPHERE_RESOURCE_UUID;
 import static org.atmosphere.cpr.ApplicationConfig.WRITE_TIMEOUT;
-import static org.atmosphere.cpr.BroadcasterLifeCyclePolicy.ATMOSPHERE_RESOURCE_POLICY.NEVER;
 import static org.atmosphere.cpr.FrameworkConfig.INJECTED_ATMOSPHERE_RESOURCE;
+
 
 /**
  * The default {@link Broadcaster} implementation.
@@ -81,8 +80,14 @@ public class DefaultBroadcaster implements Broadcaster {
     private static final String DESTROYED = "This Broadcaster has been destroyed and cannot be used {} by invoking {}";
     private static final List<AtmosphereResourceEventListener> EMPTY_LISTENERS = new ArrayList<>();
 
-    protected final ConcurrentLinkedQueue<AtmosphereResource> resources =
-            new ConcurrentLinkedQueue<>();
+    private final BroadcasterMembership membership = new BroadcasterMembership();
+    private final BroadcasterLifecycle lifecycle = new BroadcasterLifecycle();
+
+    /**
+     * Backward-compatible reference to the underlying resource queue.
+     * Subclasses (e.g. {@link org.atmosphere.util.ExcludeSessionBroadcaster}) may access this directly.
+     */
+    protected final ConcurrentLinkedQueue<AtmosphereResource> resources = membership.queue();
     protected BroadcasterConfig bc;
     protected final BlockingQueue<Deliver> messages = new LinkedBlockingQueue<>();
     protected Collection<BroadcasterListener> broadcasterListeners;
@@ -95,11 +100,10 @@ public class DefaultBroadcaster implements Broadcaster {
     protected String name = DefaultBroadcaster.class.getSimpleName();
     protected final ConcurrentLinkedQueue<Deliver> delayedBroadcast = new ConcurrentLinkedQueue<>();
     protected final ConcurrentLinkedQueue<Deliver> broadcastOnResume = new ConcurrentLinkedQueue<>();
-    protected final ConcurrentLinkedQueue<BroadcasterLifeCyclePolicyListener> lifeCycleListeners = new ConcurrentLinkedQueue<>();
     protected final ConcurrentHashMap<String, WriteQueue> writeQueues = new ConcurrentHashMap<>();
     protected final WriteQueue uniqueWriteQueue = new WriteQueue("-1");
     protected final AtomicInteger dispatchThread = new AtomicInteger();
-    
+
     private final ReentrantLock awaitLock = new ReentrantLock();
     private final Condition awaitCondition = awaitLock.newCondition();
     private final ReentrantLock lock = new ReentrantLock();
@@ -112,17 +116,12 @@ public class DefaultBroadcaster implements Broadcaster {
     private POLICY policy = POLICY.FIFO;
     private final AtomicLong maxSuspendResource = new AtomicLong(-1);
     private final AtomicBoolean requestScoped = new AtomicBoolean(false);
-    private final AtomicBoolean recentActivity = new AtomicBoolean(false);
-    private BroadcasterLifeCyclePolicy lifeCyclePolicy = new BroadcasterLifeCyclePolicy.Builder()
-            .policy(NEVER).build();
     protected URI uri;
     protected AtmosphereConfig config;
     private final AtomicBoolean outOfOrderBroadcastSupported = new AtomicBoolean(false);
     protected int writeTimeoutInSecond = -1;
     protected int waitTime = POLLING_DEFAULT;
     private boolean backwardCompatible;
-    private LifecycleHandler lifecycleHandler;
-    private Future<?> currentLifecycleTask;
     private boolean cacheOnIOFlushException = true;
     protected boolean sharedListeners;
     protected boolean candidateForPoolable;
@@ -209,7 +208,7 @@ public class DefaultBroadcaster implements Broadcaster {
                 if (bc != null) {
                     bc.destroy();
                 }
-                lifeCycleListeners.clear();
+                lifecycle.clearListeners();
                 delayedBroadcast.clear();
                 if (!sharedListeners) {
                     broadcasterListeners.clear();
@@ -234,7 +233,7 @@ public class DefaultBroadcaster implements Broadcaster {
 
     @Override
     public Collection<AtmosphereResource> getAtmosphereResources() {
-        return Collections.unmodifiableCollection(resources);
+        return membership.getResources();
     }
 
     @Override
@@ -364,23 +363,22 @@ public class DefaultBroadcaster implements Broadcaster {
 
     @Override
     public void setBroadcasterLifeCyclePolicy(final BroadcasterLifeCyclePolicy lifeCyclePolicy) {
-        this.lifeCyclePolicy = lifeCyclePolicy;
-        if (lifecycleHandler != null) lifecycleHandler.on(this);
+        lifecycle.setPolicy(lifeCyclePolicy, this);
     }
 
     @Override
     public BroadcasterLifeCyclePolicy getBroadcasterLifeCyclePolicy() {
-        return lifeCyclePolicy;
+        return lifecycle.policy();
     }
 
     @Override
     public void addBroadcasterLifeCyclePolicyListener(BroadcasterLifeCyclePolicyListener b) {
-        lifeCycleListeners.add(b);
+        lifecycle.addLifeCycleListener(b);
     }
 
     @Override
     public void removeBroadcasterLifeCyclePolicyListener(BroadcasterLifeCyclePolicyListener b) {
-        lifeCycleListeners.remove(b);
+        lifecycle.removeLifeCycleListener(b);
     }
 
     @Override
@@ -595,7 +593,7 @@ public class DefaultBroadcaster implements Broadcaster {
     }
 
     protected void deliverPush(Deliver deliver, boolean rec) {
-        recentActivity.set(true);
+        lifecycle.recentActivity().set(true);
 
         Object prevMessage = deliver.message;
         if (rec && !delayedBroadcast.isEmpty()) {
@@ -1730,11 +1728,11 @@ public class DefaultBroadcaster implements Broadcaster {
     }
 
     public BroadcasterLifeCyclePolicy lifeCyclePolicy() {
-        return lifeCyclePolicy;
+        return lifecycle.policy();
     }
 
     public ConcurrentLinkedQueue<BroadcasterLifeCyclePolicyListener> lifeCycleListeners() {
-        return lifeCycleListeners;
+        return lifecycle.lifeCycleListeners();
     }
 
     public BlockingQueue<Deliver> messages() {
@@ -1754,24 +1752,42 @@ public class DefaultBroadcaster implements Broadcaster {
     }
 
     public AtomicBoolean recentActivity() {
-        return recentActivity;
+        return lifecycle.recentActivity();
     }
 
     public LifecycleHandler lifecycleHandler() {
-        return lifecycleHandler;
+        return lifecycle.lifecycleHandler();
     }
 
     public DefaultBroadcaster lifecycleHandler(LifecycleHandler lifecycleHandler) {
-        this.lifecycleHandler = lifecycleHandler;
+        lifecycle.lifecycleHandler(lifecycleHandler);
         return this;
     }
 
     public Future<?> currentLifecycleTask() {
-        return currentLifecycleTask;
+        return lifecycle.currentLifecycleTask();
     }
 
     public DefaultBroadcaster currentLifecycleTask(Future<?> currentLifecycleTask) {
-        this.currentLifecycleTask = currentLifecycleTask;
+        lifecycle.currentLifecycleTask(currentLifecycleTask);
         return this;
+    }
+
+    /**
+     * Return the {@link BroadcasterMembership} managing resource subscriptions.
+     *
+     * @return the membership instance
+     */
+    public BroadcasterMembership membership() {
+        return membership;
+    }
+
+    /**
+     * Return the {@link BroadcasterLifecycle} managing lifecycle policy.
+     *
+     * @return the lifecycle instance
+     */
+    public BroadcasterLifecycle lifecycle() {
+        return lifecycle;
     }
 }

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/FrameworkBootstrap.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/FrameworkBootstrap.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2008-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.cpr;
+
+import org.atmosphere.util.ServletContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+
+/**
+ * Encapsulates the {@link AtmosphereFramework} initialization pipeline.
+ * <p>
+ * This class extracts the multi-phase init sequence from {@code AtmosphereFramework.init(ServletConfig, boolean)}
+ * into well-named methods, making the boot process easier to follow and maintain. The public API of
+ * {@link AtmosphereFramework} is unchanged; only the internal wiring is delegated here.
+ * <p>
+ * Lifecycle:
+ * <pre>
+ *   new FrameworkBootstrap(framework).bootstrap(sc);
+ * </pre>
+ *
+ * @author Jeanfrancois Arcand
+ */
+final class FrameworkBootstrap {
+
+    private static final Logger logger = LoggerFactory.getLogger(FrameworkBootstrap.class);
+
+    private final AtmosphereFramework framework;
+
+    FrameworkBootstrap(AtmosphereFramework framework) {
+        this.framework = framework;
+    }
+
+    /**
+     * Execute the full initialization pipeline. This method is called from
+     * {@link AtmosphereFramework#init(ServletConfig, boolean)} after the early-return guard.
+     *
+     * @param sc   the wrapped ServletConfig
+     * @param wrap whether to wrap the ServletConfig with init-param merging
+     * @throws ServletException if any phase fails
+     */
+    void bootstrap(ServletConfig sc, boolean wrap) throws ServletException {
+        // Phase 0: Bootstrap — wire config, system properties, meta-services
+        phaseBootstrap(sc, wrap);
+
+        try {
+            ServletContextFactory.getDefault().init(sc.getServletContext());
+
+            // Phase 1: Parse configuration from init-params
+            phaseParseConfiguration();
+
+            // Phase 2: Broadcaster infrastructure
+            phaseBroadcasterInfrastructure();
+
+            // Phase 3: Classpath scanning and annotation processing
+            phaseClasspathScanning();
+
+            // Phase 4: Re-configure after annotations have been processed
+            phasePostAnnotationConfiguration();
+
+            // Phase 5: Handler and interceptor initialization
+            phaseHandlerAndInterceptorInit();
+
+            // Phase 6: Finalization — analytics, shutdown hook, diagnostics
+            phaseFinalization(sc);
+
+        } catch (Throwable t) {
+            logger.error("Failed to initialize Atmosphere Framework", t);
+
+            if (t instanceof ServletException se) {
+                throw se;
+            }
+
+            throw new ServletException(t);
+        }
+
+        framework.isInit = true;
+        framework.config.initComplete();
+        framework.onPostInit();
+    }
+
+    // ----------------------------------------------------------------
+    // Phase 0: Bootstrap
+    // ----------------------------------------------------------------
+
+    private void phaseBootstrap(ServletConfig sc, boolean wrap) {
+        framework.servletConfig(sc, wrap);
+        framework.readSystemProperties();
+        framework.populateBroadcasterType();
+        framework.populateObjectFactoryType();
+        framework.loadMetaService();
+        framework.onPreInit();
+    }
+
+    // ----------------------------------------------------------------
+    // Phase 1: Parse configuration
+    // ----------------------------------------------------------------
+
+    private void phaseParseConfiguration() throws InstantiationException, IllegalAccessException {
+        framework.preventOOM();
+        framework.doInitParams(framework.servletConfig);
+        framework.doInitParamsForWebSocket(framework.servletConfig);
+        framework.lookupDefaultObjectFactoryType();
+
+        if (logger.isTraceEnabled()) {
+            framework.asyncSupportListener(
+                    framework.newClassInstance(AsyncSupportListener.class, AsyncSupportListenerAdapter.class));
+        }
+        framework.configureObjectFactory();
+    }
+
+    // ----------------------------------------------------------------
+    // Phase 2: Broadcaster infrastructure
+    // ----------------------------------------------------------------
+
+    private void phaseBroadcasterInfrastructure() {
+        framework.configureAnnotationPackages();
+        framework.configureBroadcasterFactory();
+        framework.configureMetaBroadcaster();
+        framework.configureAtmosphereResourceFactory();
+        if (framework.isSessionSupportSpecified) {
+            framework.sessionFactory();
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Phase 3: Classpath scanning
+    // ----------------------------------------------------------------
+
+    private void phaseClasspathScanning() throws Exception {
+        framework.configureScanningPackage(framework.servletConfig, ApplicationConfig.ANNOTATION_PACKAGE);
+        framework.configureScanningPackage(framework.servletConfig, FrameworkConfig.JERSEY2_SCANNING_PACKAGE);
+        framework.configureScanningPackage(framework.servletConfig, FrameworkConfig.JERSEY_SCANNING_PACKAGE);
+        framework.defaultPackagesToScan();
+        framework.installAnnotationProcessor(framework.servletConfig);
+        framework.autoConfigureService(framework.servletConfig.getServletContext());
+    }
+
+    // ----------------------------------------------------------------
+    // Phase 4: Re-configure after annotations
+    // ----------------------------------------------------------------
+
+    private void phasePostAnnotationConfiguration() throws ServletException {
+        framework.configureBroadcasterFactory();
+        framework.patchContainer();
+        framework.configureBroadcaster();
+        framework.loadConfiguration(framework.servletConfig);
+    }
+
+    // ----------------------------------------------------------------
+    // Phase 5: Handler and interceptor initialization
+    // ----------------------------------------------------------------
+
+    private void phaseHandlerAndInterceptorInit() throws ServletException {
+        framework.initWebSocket();
+        framework.initEndpointMapper();
+        framework.initDefaultSerializer();
+        framework.autoDetectContainer();
+        framework.configureWebDotXmlAtmosphereHandler(framework.servletConfig);
+        framework.asyncSupport.init(framework.servletConfig);
+        framework.initAtmosphereHandler(framework.servletConfig);
+        framework.configureAtmosphereInterceptor(framework.servletConfig);
+    }
+
+    // ----------------------------------------------------------------
+    // Phase 6: Finalization
+    // ----------------------------------------------------------------
+
+    private void phaseFinalization(ServletConfig sc) {
+        framework.analytics();
+        if (sc.getServletContext() != null) {
+            sc.getServletContext().setAttribute(
+                    BroadcasterFactory.class.getName(),
+                    framework.broadcasterSetup.broadcasterFactory());
+        }
+
+        String s = framework.config.getInitParameter(ApplicationConfig.BROADCASTER_SHARABLE_THREAD_POOLS);
+        if (s != null) {
+            framework.sharedThreadPools = Boolean.parseBoolean(s);
+        }
+
+        framework.shutdownHook = new Thread(framework::destroy);
+        Runtime.getRuntime().addShutdownHook(framework.shutdownHook);
+
+        if (logger.isInfoEnabled()) {
+            framework.info();
+        }
+        if (framework.initializationError != null) {
+            logger.trace("ContainerInitalizer exception. May not be an issue if Atmosphere started properly ",
+                    framework.initializationError);
+        }
+        framework.universe();
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/FrameworkConfig.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/FrameworkConfig.java
@@ -144,7 +144,7 @@ public interface FrameworkConfig {
     /**
      * Throw Exception from cloned request.
      */
-    String THROW_EXCEPTION_ON_CLONED_REQUEST = AtmosphereRequestImpl.NoOpsRequest.class.getName() + ".throwExceptionOnClonedRequest";
+    String THROW_EXCEPTION_ON_CLONED_REQUEST = NoOpsRequest.class.getName() + ".throwExceptionOnClonedRequest";
     /**
      * The subject for the current request.
      */

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/FrameworkDiagnostics.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/FrameworkDiagnostics.java
@@ -161,7 +161,7 @@ final class FrameworkDiagnostics {
                     var tag = body.substring(start, end);
                     var latestVersion = tag.startsWith("atmosphere-") ? tag.substring(11) : tag;
 
-                    if (latestVersion.compareTo(currentVersion) > 0
+                    if (isNewerVersion(latestVersion, currentVersion)
                             && !latestVersion.toLowerCase().contains("rc")
                             && !latestVersion.toLowerCase().contains("beta")) {
                         logger.info("\n\n\tAtmosphere {} is available (you are running {})"
@@ -177,5 +177,23 @@ final class FrameworkDiagnostics {
         });
         t.setDaemon(true);
         t.start();
+    }
+
+    /**
+     * Compares two version strings numerically by splitting on ".".
+     * Returns true if {@code latest} is newer than {@code current}.
+     */
+    static boolean isNewerVersion(String latest, String current) {
+        String[] lParts = latest.split("\\.");
+        String[] cParts = current.split("\\.");
+        int len = Math.max(lParts.length, cParts.length);
+        for (int i = 0; i < len; i++) {
+            int l = i < lParts.length ? Integer.parseInt(lParts[i]) : 0;
+            int c = i < cParts.length ? Integer.parseInt(cParts[i]) : 0;
+            if (l != c) {
+                return l > c;
+            }
+        }
+        return false;
     }
 }

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/InputStreamServletAdapter.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/InputStreamServletAdapter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2008-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.cpr;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+
+import java.io.InputStream;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A {@link ServletInputStream} adapter that wraps a standard {@link InputStream}.
+ * <p>
+ * This class was originally the inner class {@code IS} in {@link AtmosphereRequestImpl}.
+ *
+ * @author Jeanfrancois Arcand
+ */
+final class InputStreamServletAdapter extends ServletInputStream {
+
+    private final InputStream innerStream;
+    private final ReentrantLock markLock = new ReentrantLock();
+
+    InputStreamServletAdapter(InputStream innerStream) {
+        super();
+        this.innerStream = innerStream;
+    }
+
+    @Override
+    public int read() throws java.io.IOException {
+        return innerStream.read();
+    }
+
+    @Override
+    public int read(byte[] bytes) throws java.io.IOException {
+        return innerStream.read(bytes);
+    }
+
+    @Override
+    public int read(byte[] bytes, int i, int i1) throws java.io.IOException {
+        return innerStream.read(bytes, i, i1);
+    }
+
+    @Override
+    public long skip(long l) throws java.io.IOException {
+        return innerStream.skip(l);
+    }
+
+    @Override
+    public int available() throws java.io.IOException {
+        return innerStream.available();
+    }
+
+    @Override
+    public void close() throws java.io.IOException {
+        innerStream.close();
+    }
+
+    @Override
+    public void mark(int i) {
+        markLock.lock();
+        try {
+            innerStream.mark(i);
+        } finally {
+            markLock.unlock();
+        }
+    }
+
+    @Override
+    public void reset() throws java.io.IOException {
+        markLock.lock();
+        try {
+            innerStream.reset();
+        } finally {
+            markLock.unlock();
+        }
+    }
+
+    @Override
+    public boolean markSupported() {
+        return innerStream.markSupported();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return false;
+    }
+
+    @Override
+    public boolean isReady() {
+        return false;
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/NoOpsRequest.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/NoOpsRequest.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2008-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.cpr;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpUpgradeHandler;
+import jakarta.servlet.http.Part;
+import org.atmosphere.util.FakeHttpSession;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * A no-op {@link HttpServletRequest} implementation used as a default when no real request is available.
+ * <p>
+ * This class was originally an inner class of {@link AtmosphereRequestImpl}.
+ *
+ * @author Jeanfrancois Arcand
+ */
+public class NoOpsRequest implements HttpServletRequest {
+
+    private final boolean throwExceptionOnCloned;
+    public HttpSession fake;
+    private static final Enumeration<String> EMPTY_ENUM_STRING = Collections.enumeration(List.of());
+    private static final Enumeration<Locale> EMPTY_ENUM_LOCALE = Collections.enumeration(List.of());
+    private static final List<Part> EMPTY_ENUM_PART = List.of();
+    private static final Map<String, String[]> EMPTY_MAP_STRING = Map.of();
+    private static final String[] EMPTY_ARRAY = new String[0];
+    private final StringBuffer EMPTY_STRING_BUFFER = new StringBuffer();
+    private static final Cookie[] EMPTY_COOKIE = new Cookie[0];
+    private volatile BufferedReader voidReader;
+    private final ServletInputStream voidStream = new InputStreamServletAdapter(new ByteArrayInputStream(new byte[0]));
+
+    public NoOpsRequest() {
+        this.throwExceptionOnCloned = false;
+    }
+
+    public NoOpsRequest(boolean throwExceptionOnCloned) {
+        this.throwExceptionOnCloned = throwExceptionOnCloned;
+    }
+
+    private BufferedReader getVoidReader() {
+        if (voidReader == null) {
+            voidReader = new BufferedReader(new StringReader(""));
+        }
+        return voidReader;
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) {
+        return false;
+    }
+
+    @Override
+    public String getAuthType() {
+        return null;
+    }
+
+    @Override
+    public String getContextPath() {
+        return "";
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        return EMPTY_COOKIE;
+    }
+
+    @Override
+    public long getDateHeader(String name) {
+        return 0;
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        return EMPTY_ENUM_STRING;
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        return EMPTY_ENUM_STRING;
+    }
+
+    @Override
+    public int getIntHeader(String name) {
+        return 0;
+    }
+
+    @Override
+    public String getMethod() {
+        return "GET";
+    }
+
+    @Override
+    public Part getPart(String name) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        return EMPTY_ENUM_PART;
+    }
+
+    @Override
+    public String getPathInfo() {
+        return "";
+    }
+
+    @Override
+    public String getPathTranslated() {
+        return "";
+    }
+
+    @Override
+    public String getQueryString() {
+        return "";
+    }
+
+    @Override
+    public String getRemoteUser() {
+        return "";
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        return "";
+    }
+
+    @Override
+    public String getRequestURI() {
+        return "/";
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        return EMPTY_STRING_BUFFER;
+    }
+
+    @Override
+    public String getServletPath() {
+        return "";
+    }
+
+    @Override
+    public HttpSession getSession() {
+        return fake;
+    }
+
+    @Override
+    public String changeSessionId() {
+        return getSession(false).getId();
+    }
+
+    @Override
+    public HttpSession getSession(boolean create) {
+        if (create && fake == null) {
+            fake = new FakeHttpSession("", null, System.currentTimeMillis(), -1) {
+                @Override
+                public void invalidate() {
+                    fake = null;
+                    super.invalidate();
+                }
+            };
+        }
+        return fake;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return null;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        return false;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        return false;
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        if (this.throwExceptionOnCloned) {
+            throw new UnsupportedOperationException();
+        }
+        return false;
+    }
+
+    @Override
+    public void login(String username, String password) throws ServletException {
+        if (this.throwExceptionOnCloned) {
+            throw new ServletException();
+        }
+    }
+
+    @Override
+    public void logout() throws ServletException {
+        if (this.throwExceptionOnCloned) {
+            throw new ServletException();
+        }
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return EMPTY_ENUM_STRING;
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public int getContentLength() {
+        return 0;
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        return 0;
+    }
+
+    @Override
+    public String getContentType() {
+        return "text/plain";
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return DispatcherType.REQUEST;
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        return voidStream;
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+
+    @Override
+    public Enumeration<Locale> getLocales() {
+        return EMPTY_ENUM_LOCALE;
+    }
+
+    @Override
+    public String getLocalName() {
+        return null;
+    }
+
+    @Override
+    public int getLocalPort() {
+        return 0;
+    }
+
+    @Override
+    public String getLocalAddr() {
+        return "";
+    }
+
+    @Override
+    public String getParameter(String name) {
+        return "";
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        return EMPTY_MAP_STRING;
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        return EMPTY_ENUM_STRING;
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        return EMPTY_ARRAY;
+    }
+
+    @Override
+    public String getProtocol() {
+        return "HTTP/1.1";
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        return getVoidReader();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public String getRealPath(String path) {
+        return path;
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        return "";
+    }
+
+    @Override
+    public String getRemoteHost() {
+        return "";
+    }
+
+    @Override
+    public int getRemotePort() {
+        return 0;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        return null;
+    }
+
+    @Override
+    public String getScheme() {
+        return "ws";
+    }
+
+    @Override
+    public String getServerName() {
+        return "";
+    }
+
+    @Override
+    public int getServerPort() {
+        return 0;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return true;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+
+    }
+
+    @Override
+    public void setAttribute(String name, Object o) {
+
+    }
+
+    @Override
+    public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
+    }
+
+    @Override
+    public AsyncContext startAsync() {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest request, ServletResponse response) {
+        return null;
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/cpr/ResponseWriter.java
+++ b/modules/cpr/src/main/java/org/atmosphere/cpr/ResponseWriter.java
@@ -1,0 +1,720 @@
+/*
+ * Copyright 2008-2026 Async-IO.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.atmosphere.cpr;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletResponse;
+import org.atmosphere.util.HtmlEncoder;
+import org.atmosphere.websocket.WebSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.atmosphere.cpr.ApplicationConfig.PROPERTY_USE_STREAM;
+
+/**
+ * Encapsulates the async writing and I/O delegation logic for {@link AtmosphereResponseImpl}.
+ * This class manages the {@link AsyncIOWriter}, stream/writer creation, buffering,
+ * flush/close operations, and the delegation decision between native response and async writer.
+ *
+ * <p>This is an internal helper class and is not part of the public API.</p>
+ */
+final class ResponseWriter {
+
+    private static final Logger logger = LoggerFactory.getLogger(ResponseWriter.class);
+    private static final ThreadLocal<Object> NO_BUFFERING = new ThreadLocal<>();
+
+    private AsyncIOWriter asyncIOWriter;
+    private boolean delegateToNativeResponse;
+    private boolean forceAsyncIOWriter;
+    private final AtomicBoolean writeStatusAndHeader;
+    private final AtomicBoolean usingStream = new AtomicBoolean(true);
+    private final AtomicReference<Object> buffered = new AtomicReference<>(null);
+    private boolean completed;
+
+    ResponseWriter(AsyncIOWriter asyncIOWriter, boolean writeStatusAndHeader) {
+        this.asyncIOWriter = asyncIOWriter;
+        this.delegateToNativeResponse = asyncIOWriter == null;
+        this.writeStatusAndHeader = new AtomicBoolean(writeStatusAndHeader);
+    }
+
+    // -- AsyncIOWriter management --
+
+    AsyncIOWriter getAsyncIOWriter() {
+        return asyncIOWriter;
+    }
+
+    void setAsyncIOWriter(AsyncIOWriter asyncIOWriter) {
+        this.asyncIOWriter = asyncIOWriter;
+        this.forceAsyncIOWriter = true;
+    }
+
+    // -- Delegation flags --
+
+    boolean isDelegateToNativeResponse() {
+        return delegateToNativeResponse;
+    }
+
+    void setDelegateToNativeResponse(boolean delegateToNativeResponse) {
+        this.delegateToNativeResponse = delegateToNativeResponse;
+    }
+
+    boolean isForceAsyncIOWriter() {
+        return forceAsyncIOWriter;
+    }
+
+    void setForceAsyncIOWriter(boolean forceAsyncIOWriter) {
+        this.forceAsyncIOWriter = forceAsyncIOWriter;
+    }
+
+    boolean getWriteStatusAndHeader() {
+        return writeStatusAndHeader.get();
+    }
+
+    void setWriteStatusAndHeader(boolean value) {
+        writeStatusAndHeader.set(value);
+    }
+
+    // -- Validation helpers --
+
+    void validAsyncIOWriter(String uuid) throws IOException {
+        if (asyncIOWriter == null) {
+            logger.trace("{} invalid state", uuid);
+            throw new IOException("AtmosphereResource Cancelled: " + uuid);
+        }
+    }
+
+    boolean validFlushOrClose(String uuid) {
+        if (asyncIOWriter == null) {
+            logger.warn("AtmosphereResponse for {} has been closed", uuid);
+            return false;
+        }
+        return true;
+    }
+
+    // -- Status and header writing --
+
+    void writeStatusAndHeaders(AtmosphereResponseImpl response) throws IOException {
+        if (writeStatusAndHeader.getAndSet(false) && !forceAsyncIOWriter) {
+            asyncIOWriter.write(response, constructStatusAndHeaders(response));
+        }
+    }
+
+    private String constructStatusAndHeaders(AtmosphereResponseImpl response) {
+        Map<String, String> headers = response.headers();
+        var b = new StringBuilder("HTTP/1.1")
+                .append(" ")
+                .append(response.getStatus())
+                .append(" ")
+                .append(response.getStatusMessage())
+                .append("\r\n");
+
+        b.append("Content-Type").append(":")
+                .append(headers.get("Content-Type") == null ? response.getContentType() : headers.get("Content-Type"))
+                .append("\r\n");
+        long contentLength = response.contentLengthValue();
+        if (contentLength != -1) {
+            b.append("Content-Length").append(":").append(contentLength).append("\r\n");
+        }
+
+        for (String s : headers.keySet()) {
+            if (!s.equalsIgnoreCase("Content-Type")) {
+                b.append(s).append(":").append(headers.get(s)).append("\r\n");
+            }
+        }
+        b.deleteCharAt(b.length() - 2);
+        b.append("\r\n\r\n");
+        return b.toString();
+    }
+
+    // -- Stream/Writer creation --
+
+    ServletOutputStream createOutputStream(AtmosphereResponseImpl response, HttpServletResponse nativeResponse) throws IOException {
+        if (forceAsyncIOWriter || !delegateToNativeResponse) {
+            return new Stream(response, isBuffering(response));
+        } else {
+            return nativeResponse.getOutputStream() != null ? nativeResponse.getOutputStream() : new ServletOutputStream() {
+                @Override
+                public boolean isReady() {
+                    return false;
+                }
+
+                @Override
+                public void setWriteListener(WriteListener writeListener) {
+                }
+
+                @Override
+                public void write(int b) {
+                }
+            };
+        }
+    }
+
+    PrintWriter createWriter(AtmosphereResponseImpl response, HttpServletResponse nativeResponse) throws IOException {
+        if (forceAsyncIOWriter || !delegateToNativeResponse) {
+            return new Writer(response, new Stream(response, isBuffering(response)));
+        } else {
+            return nativeResponse.getWriter() != null ? nativeResponse.getWriter() : new PrintWriter(new StringWriter());
+        }
+    }
+
+    // -- Error/Redirect delegation --
+
+    void sendError(AtmosphereResponseImpl response, HttpServletResponse nativeResponse, int sc, String msg) throws IOException {
+        if (forceAsyncIOWriter || !delegateToNativeResponse) {
+            response.setStatus(sc);
+
+            // Prevent StackOverflow
+            boolean b = forceAsyncIOWriter;
+            forceAsyncIOWriter = false;
+            asyncIOWriter.writeError(response, sc, msg);
+            forceAsyncIOWriter = b;
+        } else {
+            if (!nativeResponse.isCommitted()) {
+                nativeResponse.sendError(sc, msg);
+            } else {
+                logger.warn("Committed error code {} {}", sc, msg);
+            }
+        }
+    }
+
+    void sendErrorNoMessage(AtmosphereResponseImpl response, HttpServletResponse nativeResponse, int sc) throws IOException {
+        if (forceAsyncIOWriter || !delegateToNativeResponse) {
+            response.setStatus(sc);
+            // Prevent StackOverflow
+            boolean b = forceAsyncIOWriter;
+            forceAsyncIOWriter = false;
+            asyncIOWriter.writeError(response, sc, "");
+            forceAsyncIOWriter = b;
+        } else {
+            if (!nativeResponse.isCommitted()) {
+                nativeResponse.sendError(sc);
+            } else {
+                logger.warn("Committed error code {}", sc);
+            }
+        }
+    }
+
+    void sendRedirect(AtmosphereResponseImpl response, HttpServletResponse nativeResponse, String location) throws IOException {
+        if (forceAsyncIOWriter || !delegateToNativeResponse) {
+            // Prevent StackOverflow
+            boolean b = forceAsyncIOWriter;
+            forceAsyncIOWriter = false;
+            asyncIOWriter.redirect(response, location);
+            forceAsyncIOWriter = b;
+        } else {
+            nativeResponse.sendRedirect(location);
+        }
+    }
+
+    // -- Close operations --
+
+    void close(AtmosphereResponseImpl response) throws IOException {
+        if (asyncIOWriter != null) {
+            asyncIOWriter.close(response);
+        }
+    }
+
+    void closeStreamOrWriter(AtmosphereResponseImpl response) {
+        if (response.resource() != null) {
+            try {
+                if (isUsingStream(response)) {
+                    response.getOutputStream().close();
+                } else {
+                    response.getWriter().close();
+                }
+            } catch (Exception e) {
+                //https://github.com/Atmosphere/atmosphere/issues/1643
+                logger.trace("Unexpected exception", e);
+            }
+        }
+    }
+
+    // -- Write operations --
+
+    void writeString(AtmosphereResponseImpl response, HttpServletResponse nativeResponse,
+                     String data, boolean writeUsingOriginalResponse) {
+        if (nativeResponse instanceof java.lang.reflect.Proxy) {
+            writeUsingOriginalResponse = false;
+        }
+
+        String sanitized = sanitizeForOutput(data);
+        try {
+            if (isUsingStream(response)) {
+                try {
+                    OutputStream o = writeUsingOriginalResponse ? nativeResponse.getOutputStream() : response.getOutputStream();
+                    o.write(sanitized.getBytes(response.getCharacterEncoding()));
+                } catch (IllegalStateException ex) {
+                    logger.trace("", ex);
+                }
+            } else {
+                PrintWriter w = writeUsingOriginalResponse ? nativeResponse.getWriter() : response.getWriter();
+                w.write(sanitized);
+            }
+        } catch (Exception ex) {
+            handleException(response, ex);
+            throw new RuntimeException(ex);
+        }
+    }
+
+    void writeBytes(AtmosphereResponseImpl response, HttpServletResponse nativeResponse,
+                    byte[] data, boolean writeUsingOriginalResponse) {
+        if (data == null) {
+            logger.error("Cannot write null value for {}", response.resource());
+            return;
+        }
+
+        if (nativeResponse instanceof java.lang.reflect.Proxy) {
+            writeUsingOriginalResponse = false;
+        }
+
+        try {
+            if (isUsingStream(response)) {
+                try {
+                    OutputStream o = writeUsingOriginalResponse ? nativeResponse.getOutputStream() : response.getOutputStream();
+                    o.write(data);
+                } catch (IllegalStateException ex) {
+                    logger.trace("", ex);
+                }
+            } else {
+                PrintWriter w = writeUsingOriginalResponse ? nativeResponse.getWriter() : response.getWriter();
+                w.write(sanitizeForOutput(new String(data, response.getCharacterEncoding())));
+            }
+        } catch (Exception ex) {
+            handleException(response, ex);
+            throw new RuntimeException(ex);
+        }
+    }
+
+    void writeBytes(AtmosphereResponseImpl response, HttpServletResponse nativeResponse,
+                    byte[] data, int offset, int length, boolean writeUsingOriginalResponse) {
+        if (data == null) {
+            logger.error("Cannot write null value for {}", response.resource());
+            return;
+        }
+
+        if (nativeResponse instanceof java.lang.reflect.Proxy) {
+            writeUsingOriginalResponse = false;
+        }
+
+        try {
+            if (isUsingStream(response)) {
+                try {
+                    OutputStream o = writeUsingOriginalResponse ? nativeResponse.getOutputStream() : response.getOutputStream();
+                    o.write(data, offset, length);
+                } catch (IllegalStateException ex) {
+                    logger.trace("", ex);
+                }
+            } else {
+                PrintWriter w = writeUsingOriginalResponse ? nativeResponse.getWriter() : response.getWriter();
+                w.write(sanitizeForOutput(new String(data, offset, length, response.getCharacterEncoding())));
+            }
+        } catch (Exception ex) {
+            handleException(response, ex);
+            throw new RuntimeException(ex);
+        }
+    }
+
+    // -- Stream usage decision --
+
+    boolean isUsingStream(AtmosphereResponseImpl response) {
+        AtmosphereRequest atmosphereRequest = response.request();
+        if (atmosphereRequest != null) {
+            Object s = atmosphereRequest.getAttribute(PROPERTY_USE_STREAM);
+            if (s != null) {
+                usingStream.set((Boolean) s);
+            }
+        }
+
+        // Property always take first.
+        if (response.resource() != null) {
+            boolean force = response.resource().forceBinaryWrite();
+            if (!usingStream.get() && force) {
+                usingStream.set(true);
+            }
+        }
+        return usingStream.get();
+    }
+
+    // -- Sanitization --
+
+    /**
+     * Sanitize string output to prevent XSS when the response content type is HTML.
+     * For non-HTML content types (JSON, plain text, etc.), data passes through unchanged.
+     * WebSocket frames are consumed by JavaScript, not rendered as HTML, so they are
+     * never sanitized regardless of the content type.
+     */
+    String sanitizeForOutput(String data) {
+        if (data == null) {
+            return null;
+        }
+        // WebSocket frames are not rendered as HTML by the browser
+        if (asyncIOWriter instanceof WebSocket) {
+            return data;
+        }
+        String ct = getContentTypeForSanitization();
+        if (ct != null && ct.contains("html")) {
+            return HtmlEncoder.encode(data);
+        }
+        return data;
+    }
+
+    // Package-private for use by the owning response
+    private String contentTypeForSanitization;
+
+    void setContentTypeForSanitization(String contentType) {
+        this.contentTypeForSanitization = contentType;
+    }
+
+    private String getContentTypeForSanitization() {
+        return contentTypeForSanitization;
+    }
+
+    // -- Exception handling --
+
+    void handleException(AtmosphereResponseImpl response, Exception ex) {
+        AtmosphereResource r = response.resource();
+        if (r != null) {
+            r.notifyListeners(
+                    new AtmosphereResourceEventImpl((AtmosphereResourceImpl) r, true, false));
+            // Don't take any risk and remove it.
+            r.getAtmosphereConfig().resourcesFactory().remove(response.uuid());
+        }
+        logger.trace("{} unexpected I/O exception {}", response.uuid(), ex);
+    }
+
+    // -- Buffering --
+
+    void writeWithBuffering(AtmosphereResponseImpl response, Object data) throws IOException {
+        if (NO_BUFFERING.get() != null) {
+            boolean b = forceAsyncIOWriter;
+            try {
+                if (data instanceof String s) {
+                    asyncIOWriter.write(response, s);
+                } else if (data instanceof byte[] bytes) {
+                    asyncIOWriter.write(response, bytes);
+                }
+            } catch (IOException e) {
+                handleException(response, e);
+                throw e;
+            } finally {
+                forceAsyncIOWriter = b;
+            }
+        } else {
+            try {
+                NO_BUFFERING.set(Boolean.TRUE);
+                Object previous = buffered.getAndSet(data);
+                if (previous != null) {
+                    boolean b = forceAsyncIOWriter;
+                    try {
+                        if (previous instanceof String s) {
+                            asyncIOWriter.write(response, s);
+                        } else if (previous instanceof byte[] bytes) {
+                            asyncIOWriter.write(response, bytes);
+                        }
+                    } catch (IOException e) {
+                        handleException(response, e);
+                        throw e;
+                    } finally {
+                        forceAsyncIOWriter = b;
+                    }
+                }
+            } finally {
+                NO_BUFFERING.remove();
+            }
+        }
+    }
+
+    boolean isBuffering(AtmosphereResponseImpl response) {
+        AtmosphereRequest atmosphereRequest = response.request();
+        return atmosphereRequest != null
+                && Boolean.TRUE == atmosphereRequest.getAttribute(ApplicationConfig.RESPONSE_COMPLETION_AWARE);
+    }
+
+    // -- Completion --
+
+    void onComplete(AtmosphereResponseImpl response) {
+        if (!completed) {
+            completed = true;
+            try {
+                writeWithBuffering(response, null);
+            } catch (IOException e) {
+                // ignore as the exception is already handled
+            } finally {
+                //reset the completion status for the subsequent push writes
+                if (isCompletionReset(response)) {
+                    completed = false;
+                }
+            }
+        }
+    }
+
+    boolean completed() {
+        return completed;
+    }
+
+    private boolean isCompletionReset(AtmosphereResponseImpl response) {
+        AtmosphereRequest atmosphereRequest = response.request();
+        return atmosphereRequest != null
+                && Boolean.TRUE == atmosphereRequest.getAttribute(ApplicationConfig.RESPONSE_COMPLETION_RESET);
+    }
+
+    // -- Destroy support --
+
+    void destroy() {
+        asyncIOWriter = null;
+    }
+
+    // -- Inner class: Stream --
+
+    private final class Stream extends ServletOutputStream {
+        private final boolean buffering;
+        private final AtmosphereResponseImpl response;
+
+        Stream(AtmosphereResponseImpl response, boolean buffering) {
+            this.response = response;
+            this.buffering = buffering;
+        }
+
+        @Override
+        public void write(int i) throws IOException {
+            write(new byte[]{(byte) i});
+        }
+
+        @Override
+        public void write(byte[] bytes) throws IOException {
+            // Prevent StackOverflow
+            boolean b = forceAsyncIOWriter;
+            try {
+                validAsyncIOWriter(response.uuid());
+                writeStatusAndHeaders(response);
+
+                forceAsyncIOWriter = false;
+                if (buffering && !ResponseWriter.this.completed()) {
+                    writeWithBuffering(response, bytes);
+                } else {
+                    asyncIOWriter.write(response, bytes);
+                }
+            } catch (IOException e) {
+                handleException(response, e);
+                throw e;
+            } finally {
+                forceAsyncIOWriter = b;
+            }
+        }
+
+        @Override
+        public void write(byte[] bytes, int start, int offset) throws IOException {
+            // Prevent StackOverflow
+            boolean b = forceAsyncIOWriter;
+            try {
+                validAsyncIOWriter(response.uuid());
+                writeStatusAndHeaders(response);
+
+                forceAsyncIOWriter = false;
+                if (buffering && !ResponseWriter.this.completed()) {
+                    byte[] copy = new byte[offset];
+                    System.arraycopy(bytes, start, copy, 0, offset);
+                    writeWithBuffering(response, copy);
+                } else {
+                    asyncIOWriter.write(response, bytes, start, offset);
+                }
+            } catch (IOException e) {
+                handleException(response, e);
+                throw e;
+            } finally {
+                forceAsyncIOWriter = b;
+            }
+        }
+
+        @Override
+        public void flush() throws IOException {
+            if (!validFlushOrClose(response.uuid())) return;
+
+            writeStatusAndHeaders(response);
+
+            // Prevent StackOverflow
+            boolean b = forceAsyncIOWriter;
+            forceAsyncIOWriter = false;
+            try {
+                asyncIOWriter.flush(response);
+            } catch (IOException e) {
+                handleException(response, e);
+                throw e;
+            } finally {
+                forceAsyncIOWriter = b;
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            ResponseWriter.this.onComplete(response);
+            if (!validFlushOrClose(response.uuid())
+                    || asyncIOWriter instanceof KeepOpenStreamAware) return;
+
+            // Prevent StackOverflow
+            boolean b = forceAsyncIOWriter;
+            forceAsyncIOWriter = false;
+            try {
+                if (buffering && !ResponseWriter.this.completed()) {
+                    writeWithBuffering(response, null);
+                }
+                asyncIOWriter.close(response);
+            } catch (IOException e) {
+                handleException(response, e);
+                throw e;
+            } finally {
+                forceAsyncIOWriter = b;
+            }
+        }
+
+        @Override
+        public boolean isReady() {
+            return false;
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {
+        }
+    }
+
+    // -- Inner class: Writer --
+
+    private final class Writer extends PrintWriter {
+        private final AtmosphereResponseImpl response;
+
+        Writer(AtmosphereResponseImpl response, OutputStream out) {
+            super(out);
+            this.response = response;
+        }
+
+        @Override
+        public void write(char[] chars, int offset, int lenght) {
+            boolean b = forceAsyncIOWriter;
+            try {
+                validAsyncIOWriter(response.uuid());
+
+                // Prevent StackOverflow
+                writeStatusAndHeaders(response);
+                forceAsyncIOWriter = false;
+                asyncIOWriter.write(response, new String(chars, offset, lenght));
+            } catch (IOException e) {
+                handleException(response, e);
+                throw new RuntimeException(e);
+            } finally {
+                forceAsyncIOWriter = b;
+            }
+        }
+
+        @Override
+        public void write(char[] chars) {
+            boolean b = forceAsyncIOWriter;
+            try {
+                validAsyncIOWriter(response.uuid());
+
+                writeStatusAndHeaders(response);
+                // Prevent StackOverflow
+                forceAsyncIOWriter = false;
+                asyncIOWriter.write(response, new String(chars));
+            } catch (IOException e) {
+                handleException(response, e);
+                throw new RuntimeException(e);
+            } finally {
+                forceAsyncIOWriter = b;
+            }
+        }
+
+        @Override
+        public void write(String s, int offset, int lenght) {
+            boolean b = forceAsyncIOWriter;
+
+            try {
+                validAsyncIOWriter(response.uuid());
+
+                writeStatusAndHeaders(response);
+                // Prevent StackOverflow
+                forceAsyncIOWriter = false;
+                asyncIOWriter.write(response, s.substring(offset, lenght));
+            } catch (IOException e) {
+                handleException(response, e);
+                throw new RuntimeException(e);
+            } finally {
+                forceAsyncIOWriter = b;
+            }
+        }
+
+        @Override
+        public void write(String s) {
+
+            boolean b = forceAsyncIOWriter;
+            try {
+                validAsyncIOWriter(response.uuid());
+
+                writeStatusAndHeaders(response);
+                // Prevent StackOverflow
+                forceAsyncIOWriter = false;
+                asyncIOWriter.write(response, s);
+            } catch (IOException e) {
+                handleException(response, e);
+                throw new RuntimeException(e);
+            } finally {
+                forceAsyncIOWriter = b;
+            }
+        }
+
+        @Override
+        public void flush() {
+            if (!validFlushOrClose(response.uuid())) return;
+
+            boolean b = forceAsyncIOWriter;
+            try {
+                writeStatusAndHeaders(response);
+                // Prevent StackOverflow
+                forceAsyncIOWriter = false;
+                asyncIOWriter.flush(response);
+            } catch (IOException e) {
+                handleException(response, e);
+            } finally {
+                forceAsyncIOWriter = b;
+            }
+        }
+
+        @Override
+        public void close() {
+            if (!validFlushOrClose(response.uuid())
+                    || asyncIOWriter instanceof KeepOpenStreamAware) return;
+
+            // Prevent StackOverflow
+            boolean b = forceAsyncIOWriter;
+            forceAsyncIOWriter = false;
+            try {
+                asyncIOWriter.close(response);
+            } catch (IOException e) {
+                handleException(response, e);
+            } finally {
+                forceAsyncIOWriter = b;
+            }
+        }
+    }
+}

--- a/modules/cpr/src/main/java/org/atmosphere/interceptor/AtmosphereResourceStateRecovery.java
+++ b/modules/cpr/src/main/java/org/atmosphere/interceptor/AtmosphereResourceStateRecovery.java
@@ -164,7 +164,7 @@ public class AtmosphereResourceStateRecovery implements AtmosphereInterceptor {
 
                         // Force doNotSuspend.
                         if (doNotSuspend.get()) {
-                            ((AtmosphereResourceImpl) r).action().type(Action.TYPE.CONTINUE);
+                            ((AtmosphereResourceImpl) r).setAction(new Action(Action.TYPE.CONTINUE));
                         }
                         if (logger.isTraceEnabled()) {
                             logger.trace("doNotSuspend {}", doNotSuspend.get());

--- a/modules/cpr/src/main/java/org/atmosphere/interceptor/WebSocketMessageSuspendInterceptor.java
+++ b/modules/cpr/src/main/java/org/atmosphere/interceptor/WebSocketMessageSuspendInterceptor.java
@@ -32,7 +32,7 @@ public class WebSocketMessageSuspendInterceptor extends AtmosphereInterceptorAda
     public Action inspect(AtmosphereResource r) {
 
         if (Utils.webSocketMessage(r)){
-            ((AtmosphereResourceImpl) r).action().type(Action.TYPE.SUSPEND_MESSAGE);
+            ((AtmosphereResourceImpl) r).setAction(new Action(Action.TYPE.SUSPEND_MESSAGE));
         }
         return Action.CONTINUE;
     }

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereFrameworkTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereFrameworkTest.java
@@ -78,7 +78,7 @@ public class AtmosphereFrameworkTest {
         final AtomicReference<Object> value = new AtomicReference<Object>();
 
         // Intercepts interceptor call
-        final AtmosphereRequest r = new AtmosphereRequestImpl.Builder().request(new HttpServletRequestWrapper(new AtmosphereRequestImpl.NoOpsRequest()) {
+        final AtmosphereRequest r = new AtmosphereRequestImpl.Builder().request(new HttpServletRequestWrapper(new NoOpsRequest()) {
             @Override
             public void setAttribute(String name, Object o) {
                 if (MyInterceptor.class.getName().equals(name)) {

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereInterceptorTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereInterceptorTest.java
@@ -84,7 +84,7 @@ public class AtmosphereInterceptorTest {
             @Override
             public Action inspect(AtmosphereResource r) {
                 // Default is CREATED
-                AtmosphereResourceImpl.class.cast(r).action().type(Action.TYPE.CONTINUE);
+                AtmosphereResourceImpl.class.cast(r).setAction(new Action(Action.TYPE.CONTINUE));
                 return Action.CONTINUE;
             }
             @Override
@@ -111,7 +111,7 @@ public class AtmosphereInterceptorTest {
             @Override
             public Action inspect(AtmosphereResource r) {
                 // Default is CREATED
-                AtmosphereResourceImpl.class.cast(r).action().type(Action.TYPE.CONTINUE);
+                AtmosphereResourceImpl.class.cast(r).setAction(new Action(Action.TYPE.CONTINUE));
                 return Action.CONTINUE;
             }
 
@@ -131,7 +131,7 @@ public class AtmosphereInterceptorTest {
             @Override
             public Action inspect(AtmosphereResource r) {
                 // Default is CREATED
-                AtmosphereResourceImpl.class.cast(r).action().type(Action.TYPE.CREATED);
+                AtmosphereResourceImpl.class.cast(r).setAction(new Action(Action.TYPE.CREATED));
                 return Action.CONTINUE;
             }
 

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereResponseImplTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/AtmosphereResponseImplTest.java
@@ -89,6 +89,6 @@ public class AtmosphereResponseImplTest {
                 .header("header 2", null)
                 .build();
 
-        assertEquals(null, response.getHeaders("header 3"));
+        assertEquals(Collections.emptyList(), response.getHeaders("header 3"));
     }
 }

--- a/modules/cpr/src/test/java/org/atmosphere/cpr/SessionTest.java
+++ b/modules/cpr/src/test/java/org/atmosphere/cpr/SessionTest.java
@@ -15,7 +15,6 @@
  */
 package org.atmosphere.cpr;
 
-import org.atmosphere.cpr.AtmosphereRequestImpl.NoOpsRequest;
 import org.atmosphere.util.FakeHttpSession;
 
 import jakarta.servlet.ServletException;

--- a/modules/grpc/src/main/java/org/atmosphere/grpc/GrpcProcessor.java
+++ b/modules/grpc/src/main/java/org/atmosphere/grpc/GrpcProcessor.java
@@ -80,8 +80,7 @@ public class GrpcProcessor {
             if (resource instanceof AtmosphereResourceImpl impl) {
                 impl.transport(TRANSPORT.GRPC);
                 impl.atmosphereHandler(new AbstractReflectorAtmosphereHandler.Default());
-                impl.action().type(Action.TYPE.SUSPEND);
-                impl.action().timeout(-1);
+                impl.setAction(new Action(Action.TYPE.SUSPEND));
             }
             channel.resource(resource);
         } catch (Exception e) {

--- a/modules/quarkus-extension/README.md
+++ b/modules/quarkus-extension/README.md
@@ -63,7 +63,7 @@ All properties are under the `quarkus.atmosphere.*` prefix:
 | `quarkus.atmosphere.broadcaster-class` | (default) | Custom `Broadcaster` implementation |
 | `quarkus.atmosphere.broadcaster-cache-class` | (default) | Custom `BroadcasterCache` implementation |
 | `quarkus.atmosphere.load-on-startup` | `1` | Servlet load-on-startup order — **must be > 0** or the servlet will not initialize |
-| `quarkus.atmosphere.heartbeat-interval-in-seconds` | (default) | Heartbeat interval for long-polling fallback |
+| `quarkus.atmosphere.heartbeat-interval` | (default) | Heartbeat interval (e.g. `30s`, `5m`). Converted to seconds internally |
 | `quarkus.atmosphere.init-params` | (none) | Map of raw `ApplicationConfig` init params passed directly to the servlet |
 
 ## Running

--- a/modules/quarkus-extension/deployment/src/main/java/org/atmosphere/quarkus/deployment/AtmosphereProcessor.java
+++ b/modules/quarkus-extension/deployment/src/main/java/org/atmosphere/quarkus/deployment/AtmosphereProcessor.java
@@ -37,6 +37,8 @@ import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildI
 import io.quarkus.undertow.deployment.IgnoredServletContainerInitializerBuildItem;
 import io.quarkus.undertow.deployment.ServletBuildItem;
 import io.quarkus.websockets.client.deployment.ServerWebSocketContainerBuildItem;
+import org.atmosphere.cpr.AtmosphereAnnotations;
+import org.atmosphere.cpr.AtmosphereReflectiveTypes;
 import org.atmosphere.quarkus.runtime.AtmosphereConfig;
 import org.atmosphere.quarkus.runtime.AtmosphereRecorder;
 import org.atmosphere.quarkus.runtime.QuarkusAtmosphereServlet;
@@ -52,32 +54,11 @@ class AtmosphereProcessor {
 
     private static final String FEATURE = "atmosphere";
 
-    private static final DotName[] ATMOSPHERE_ANNOTATIONS = {
-            DotName.createSimple("org.atmosphere.config.service.AtmosphereHandlerService"),
-            DotName.createSimple("org.atmosphere.config.service.BroadcasterCacheService"),
-            DotName.createSimple("org.atmosphere.config.service.BroadcasterFilterService"),
-            DotName.createSimple("org.atmosphere.config.service.BroadcasterFactoryService"),
-            DotName.createSimple("org.atmosphere.config.service.BroadcasterService"),
-            DotName.createSimple("org.atmosphere.config.service.WebSocketFactoryService"),
-            DotName.createSimple("org.atmosphere.config.service.WebSocketHandlerService"),
-            DotName.createSimple("org.atmosphere.config.service.WebSocketProtocolService"),
-            DotName.createSimple("org.atmosphere.config.service.AtmosphereInterceptorService"),
-            DotName.createSimple("org.atmosphere.config.service.BroadcasterListenerService"),
-            DotName.createSimple("org.atmosphere.config.service.AsyncSupportService"),
-            DotName.createSimple("org.atmosphere.config.service.AsyncSupportListenerService"),
-            DotName.createSimple("org.atmosphere.config.service.WebSocketProcessorService"),
-            DotName.createSimple("org.atmosphere.config.service.BroadcasterCacheInspectorService"),
-            DotName.createSimple("org.atmosphere.config.service.ManagedService"),
-            DotName.createSimple("org.atmosphere.config.service.AtmosphereService"),
-            DotName.createSimple("org.atmosphere.config.service.EndpointMapperService"),
-            DotName.createSimple("org.atmosphere.config.service.BroadcasterCacheListenerService"),
-            DotName.createSimple("org.atmosphere.config.AtmosphereAnnotation"),
-            DotName.createSimple("org.atmosphere.config.service.AtmosphereResourceFactoryService"),
-            DotName.createSimple("org.atmosphere.config.service.AtmosphereFrameworkListenerService"),
-            DotName.createSimple("org.atmosphere.config.service.AtmosphereResourceListenerService"),
-            DotName.createSimple("org.atmosphere.config.service.UUIDProviderService"),
-            DotName.createSimple("org.atmosphere.config.service.RoomService"),
-    };
+    // Source of truth: AtmosphereAnnotations.coreAnnotationNames()
+    private static final DotName[] ATMOSPHERE_ANNOTATIONS =
+            AtmosphereAnnotations.coreAnnotationNames().stream()
+                    .map(DotName::createSimple)
+                    .toArray(DotName[]::new);
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -168,68 +149,23 @@ class AtmosphereProcessor {
                             .build());
         }
 
+        // Quarkus runtime classes (not in the shared registry — Quarkus-specific)
         reflectiveClasses.produce(
                 ReflectiveClassBuildItem.builder(
-                                // Quarkus runtime classes
                                 "org.atmosphere.quarkus.runtime.QuarkusAtmosphereObjectFactory",
                                 "org.atmosphere.quarkus.runtime.QuarkusAtmosphereServlet",
                                 "org.atmosphere.quarkus.runtime.QuarkusJSR356AsyncSupport",
-                                "org.atmosphere.quarkus.runtime.LazyAtmosphereConfigurator",
-                                // JSR-356 WebSocket endpoint
-                                "org.atmosphere.container.JSR356Endpoint",
-                                // Core framework classes
-                                "org.atmosphere.cpr.AtmosphereFramework",
-                                "org.atmosphere.cpr.DefaultBroadcaster",
-                                "org.atmosphere.cpr.DefaultBroadcasterFactory",
-                                "org.atmosphere.cpr.DefaultAtmosphereResourceFactory",
-                                "org.atmosphere.cpr.DefaultMetaBroadcaster",
-                                "org.atmosphere.cpr.DefaultAtmosphereResourceSessionFactory",
-                                "org.atmosphere.inject.InjectableObjectFactory",
-                                "org.atmosphere.inject.AtmosphereProducers",
-                                // Injectable SPI implementations (loaded via ServiceLoader)
-                                "org.atmosphere.inject.AtmosphereConfigInjectable",
-                                "org.atmosphere.inject.AtmosphereFrameworkInjectable",
-                                "org.atmosphere.inject.AtmosphereResourceFactoryInjectable",
-                                "org.atmosphere.inject.AtmosphereResourceSessionFactoryInjectable",
-                                "org.atmosphere.inject.BroadcasterFactoryInjectable",
-                                "org.atmosphere.inject.MetaBroadcasterInjectable",
-                                "org.atmosphere.inject.WebSocketFactoryInjectable",
-                                "org.atmosphere.inject.PostConstructIntrospector",
-                                "org.atmosphere.inject.BroadcasterIntrospector",
-                                "org.atmosphere.inject.AtmosphereResourceIntrospector",
-                                "org.atmosphere.inject.AtmosphereRequestIntrospector",
-                                "org.atmosphere.inject.AtmosphereResponseIntrospector",
-                                "org.atmosphere.inject.AtmosphereResourceEventIntrospector",
-                                "org.atmosphere.inject.PathParamIntrospector",
-                                // Core classes instantiated via newClassInstance / getDeclaredConstructor
-                                "org.atmosphere.cpr.AtmosphereResourceImpl",
-                                "org.atmosphere.cpr.AtmosphereRequestImpl",
-                                "org.atmosphere.cpr.AtmosphereResponseImpl",
-                                "org.atmosphere.config.managed.ManagedAtmosphereHandler",
-                                "org.atmosphere.config.managed.AtmosphereHandlerServiceInterceptor",
-                                "org.atmosphere.cpr.DefaultAtmosphereObjectFactory",
-                                // AsyncSupport implementations (resolved by DefaultAsyncSupportResolver)
-                                "org.atmosphere.container.JSR356AsyncSupport",
-                                "org.atmosphere.container.Servlet30CometSupport",
-                                // WebSocket internals
-                                "org.atmosphere.websocket.DefaultWebSocketProcessor",
-                                "org.atmosphere.websocket.DefaultWebSocketFactory",
-                                // Protocol
-                                "org.atmosphere.websocket.protocol.SimpleHttpProtocol",
-                                // Default interceptors (loaded by name via IOUtils.loadClass)
-                                "org.atmosphere.interceptor.CorsInterceptor",
-                                "org.atmosphere.interceptor.CacheHeadersInterceptor",
-                                "org.atmosphere.interceptor.PaddingAtmosphereInterceptor",
-                                "org.atmosphere.interceptor.AndroidAtmosphereInterceptor",
-                                "org.atmosphere.interceptor.HeartbeatInterceptor",
-                                "org.atmosphere.interceptor.SSEAtmosphereInterceptor",
-                                "org.atmosphere.interceptor.JavaScriptProtocol",
-                                "org.atmosphere.interceptor.WebSocketMessageSuspendInterceptor",
-                                "org.atmosphere.interceptor.OnDisconnectInterceptor",
-                                "org.atmosphere.interceptor.IdleResourceInterceptor",
-                                "org.atmosphere.interceptor.SuspendTrackerInterceptor",
-                                // Annotation processor
-                                "org.atmosphere.cpr.DefaultAnnotationProcessor")
+                                "org.atmosphere.quarkus.runtime.LazyAtmosphereConfigurator")
+                        .constructors()
+                        .methods()
+                        .fields()
+                        .reason("Quarkus Atmosphere runtime classes require reflection")
+                        .build());
+
+        // Core Atmosphere types (source of truth: AtmosphereReflectiveTypes)
+        reflectiveClasses.produce(
+                ReflectiveClassBuildItem.builder(
+                                AtmosphereReflectiveTypes.coreTypes().toArray(new String[0]))
                         .constructors()
                         .methods()
                         .fields()
@@ -245,8 +181,7 @@ class AtmosphereProcessor {
                     Thread.currentThread().getContextClassLoader());
             reflectiveClasses.produce(
                     ReflectiveClassBuildItem.builder(
-                                    "org.atmosphere.pool.UnboundedApachePoolableProvider",
-                                    "org.atmosphere.pool.BoundedApachePoolableProvider")
+                                    AtmosphereReflectiveTypes.poolTypes().toArray(new String[0]))
                             .constructors()
                             .methods()
                             .fields()
@@ -371,9 +306,9 @@ class AtmosphereProcessor {
         config.broadcasterCacheClass().ifPresent(b ->
                 builder.addInitParam("org.atmosphere.cpr.broadcasterCacheClass", b));
 
-        config.heartbeatIntervalInSeconds().ifPresent(h ->
+        config.heartbeatInterval().ifPresent(h ->
                 builder.addInitParam("org.atmosphere.cpr.AtmosphereResource.heartbeatFrequencyInSeconds",
-                        String.valueOf(h)));
+                        String.valueOf(h.toSeconds())));
 
         for (Map.Entry<String, String> entry : config.initParams().entrySet()) {
             builder.addInitParam(entry.getKey(), entry.getValue());

--- a/modules/quarkus-extension/runtime/src/main/java/org/atmosphere/quarkus/runtime/AtmosphereConfig.java
+++ b/modules/quarkus-extension/runtime/src/main/java/org/atmosphere/quarkus/runtime/AtmosphereConfig.java
@@ -15,6 +15,7 @@
  */
 package org.atmosphere.quarkus.runtime;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
@@ -71,9 +72,10 @@ public interface AtmosphereConfig {
     Optional<Boolean> websocketSupport();
 
     /**
-     * The heartbeat interval in seconds.
+     * The heartbeat interval. Accepts ISO-8601 duration or Quarkus shorthand
+     * ({@code 30s}, {@code 5m}, {@code 1h}). Converted to seconds internally.
      */
-    Optional<Integer> heartbeatIntervalInSeconds();
+    Optional<Duration> heartbeatInterval();
 
     /**
      * Additional Atmosphere init parameters passed to the servlet.

--- a/modules/spring-boot-starter/src/main/java/org/atmosphere/spring/boot/AtmosphereAutoConfiguration.java
+++ b/modules/spring-boot-starter/src/main/java/org/atmosphere/spring/boot/AtmosphereAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.atmosphere.spring.boot;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,30 +26,8 @@ import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 
 import org.atmosphere.config.AtmosphereAnnotation;
-import org.atmosphere.config.service.AsyncSupportListenerService;
-import org.atmosphere.config.service.AsyncSupportService;
-import org.atmosphere.config.service.AtmosphereFrameworkListenerService;
-import org.atmosphere.config.service.AtmosphereHandlerService;
-import org.atmosphere.config.service.AtmosphereInterceptorService;
-import org.atmosphere.config.service.AtmosphereResourceFactoryService;
-import org.atmosphere.config.service.AtmosphereResourceListenerService;
-import org.atmosphere.config.service.AtmosphereService;
-import org.atmosphere.config.service.BroadcasterCacheInspectorService;
-import org.atmosphere.config.service.BroadcasterCacheListenerService;
-import org.atmosphere.config.service.BroadcasterCacheService;
-import org.atmosphere.config.service.BroadcasterFactoryService;
-import org.atmosphere.config.service.BroadcasterFilterService;
-import org.atmosphere.config.service.BroadcasterListenerService;
-import org.atmosphere.config.service.BroadcasterService;
-import org.atmosphere.config.service.EndpointMapperService;
-import org.atmosphere.config.service.ManagedService;
-import org.atmosphere.config.service.RoomService;
-import org.atmosphere.config.service.UUIDProviderService;
-import org.atmosphere.config.service.WebSocketFactoryService;
-import org.atmosphere.config.service.WebSocketHandlerService;
-import org.atmosphere.config.service.WebSocketProcessorService;
-import org.atmosphere.config.service.WebSocketProtocolService;
 import org.atmosphere.cpr.ApplicationConfig;
+import org.atmosphere.cpr.AtmosphereAnnotations;
 import org.atmosphere.cpr.AtmosphereFramework;
 import org.atmosphere.cpr.AtmosphereServlet;
 import org.atmosphere.cpr.DefaultAnnotationProcessor;
@@ -79,33 +58,9 @@ public class AtmosphereAutoConfiguration {
 
     private static final Logger logger = LoggerFactory.getLogger(AtmosphereAutoConfiguration.class);
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static final Class<? extends Annotation>[] ATMOSPHERE_ANNOTATIONS = new Class[]{
-            AtmosphereHandlerService.class,
-            BroadcasterCacheService.class,
-            BroadcasterFilterService.class,
-            BroadcasterFactoryService.class,
-            BroadcasterService.class,
-            WebSocketFactoryService.class,
-            WebSocketHandlerService.class,
-            WebSocketProtocolService.class,
-            AtmosphereInterceptorService.class,
-            BroadcasterListenerService.class,
-            AsyncSupportService.class,
-            AsyncSupportListenerService.class,
-            WebSocketProcessorService.class,
-            BroadcasterCacheInspectorService.class,
-            ManagedService.class,
-            AtmosphereService.class,
-            EndpointMapperService.class,
-            BroadcasterCacheListenerService.class,
-            AtmosphereAnnotation.class,
-            AtmosphereResourceFactoryService.class,
-            AtmosphereFrameworkListenerService.class,
-            AtmosphereResourceListenerService.class,
-            UUIDProviderService.class,
-            RoomService.class
-    };
+    // Source of truth: AtmosphereAnnotations.coreAnnotations()
+    private static final List<Class<? extends Annotation>> ATMOSPHERE_ANNOTATIONS =
+            AtmosphereAnnotations.coreAnnotations();
 
     @Bean
     @ConditionalOnMissingBean
@@ -270,9 +225,9 @@ public class AtmosphereAutoConfiguration {
                     String.valueOf(properties.getWebsocketSupport()));
         }
 
-        if (properties.getHeartbeatIntervalInSeconds() != null) {
+        if (properties.getHeartbeatInterval() != null) {
             initParams.put(ApplicationConfig.HEARTBEAT_INTERVAL_IN_SECONDS,
-                    String.valueOf(properties.getHeartbeatIntervalInSeconds()));
+                    String.valueOf(properties.getHeartbeatInterval().toSeconds()));
         }
 
         initParams.putAll(properties.getInitParams());

--- a/modules/spring-boot-starter/src/main/java/org/atmosphere/spring/boot/AtmosphereProperties.java
+++ b/modules/spring-boot-starter/src/main/java/org/atmosphere/spring/boot/AtmosphereProperties.java
@@ -15,10 +15,13 @@
  */
 package org.atmosphere.spring.boot;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
 
 @ConfigurationProperties(prefix = "atmosphere")
 public class AtmosphereProperties {
@@ -37,7 +40,8 @@ public class AtmosphereProperties {
 
     private Boolean websocketSupport;
 
-    private Integer heartbeatIntervalInSeconds;
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration heartbeatInterval;
 
     private DurableSessionsProperties durableSessions = new DurableSessionsProperties();
 
@@ -101,12 +105,12 @@ public class AtmosphereProperties {
         this.websocketSupport = websocketSupport;
     }
 
-    public Integer getHeartbeatIntervalInSeconds() {
-        return heartbeatIntervalInSeconds;
+    public Duration getHeartbeatInterval() {
+        return heartbeatInterval;
     }
 
-    public void setHeartbeatIntervalInSeconds(Integer heartbeatIntervalInSeconds) {
-        this.heartbeatIntervalInSeconds = heartbeatIntervalInSeconds;
+    public void setHeartbeatInterval(Duration heartbeatInterval) {
+        this.heartbeatInterval = heartbeatInterval;
     }
 
     public Map<String, String> getInitParams() {
@@ -170,9 +174,11 @@ public class AtmosphereProperties {
 
         private boolean enabled = false;
 
-        private long sessionTtlMinutes = 1440;
+        @DurationUnit(ChronoUnit.MINUTES)
+        private Duration sessionTtl = Duration.ofMinutes(1440);
 
-        private long cleanupIntervalSeconds = 60;
+        @DurationUnit(ChronoUnit.SECONDS)
+        private Duration cleanupInterval = Duration.ofSeconds(60);
 
         public boolean isEnabled() {
             return enabled;
@@ -182,20 +188,20 @@ public class AtmosphereProperties {
             this.enabled = enabled;
         }
 
-        public long getSessionTtlMinutes() {
-            return sessionTtlMinutes;
+        public Duration getSessionTtl() {
+            return sessionTtl;
         }
 
-        public void setSessionTtlMinutes(long sessionTtlMinutes) {
-            this.sessionTtlMinutes = sessionTtlMinutes;
+        public void setSessionTtl(Duration sessionTtl) {
+            this.sessionTtl = sessionTtl;
         }
 
-        public long getCleanupIntervalSeconds() {
-            return cleanupIntervalSeconds;
+        public Duration getCleanupInterval() {
+            return cleanupInterval;
         }
 
-        public void setCleanupIntervalSeconds(long cleanupIntervalSeconds) {
-            this.cleanupIntervalSeconds = cleanupIntervalSeconds;
+        public void setCleanupInterval(Duration cleanupInterval) {
+            this.cleanupInterval = cleanupInterval;
         }
     }
 }

--- a/modules/spring-boot-starter/src/main/java/org/atmosphere/spring/boot/AtmosphereRuntimeHints.java
+++ b/modules/spring-boot-starter/src/main/java/org/atmosphere/spring/boot/AtmosphereRuntimeHints.java
@@ -15,49 +15,7 @@
  */
 package org.atmosphere.spring.boot;
 
-import org.atmosphere.cpr.AtmosphereFramework;
-import org.atmosphere.cpr.AtmosphereRequestImpl;
-import org.atmosphere.cpr.AtmosphereResourceImpl;
-import org.atmosphere.cpr.AtmosphereResponseImpl;
-import org.atmosphere.cpr.DefaultAtmosphereResourceFactory;
-import org.atmosphere.cpr.DefaultAtmosphereResourceSessionFactory;
-import org.atmosphere.cpr.DefaultBroadcaster;
-import org.atmosphere.cpr.DefaultBroadcasterFactory;
-import org.atmosphere.cpr.DefaultMetaBroadcaster;
-import org.atmosphere.config.managed.ManagedAtmosphereHandler;
-import org.atmosphere.inject.AtmosphereConfigInjectable;
-import org.atmosphere.inject.AtmosphereFrameworkInjectable;
-import org.atmosphere.inject.AtmosphereProducers;
-import org.atmosphere.inject.AtmosphereRequestIntrospector;
-import org.atmosphere.inject.AtmosphereResourceEventIntrospector;
-import org.atmosphere.inject.AtmosphereResourceFactoryInjectable;
-import org.atmosphere.inject.AtmosphereResourceIntrospector;
-import org.atmosphere.inject.AtmosphereResourceSessionFactoryInjectable;
-import org.atmosphere.inject.AtmosphereResponseIntrospector;
-import org.atmosphere.inject.BroadcasterFactoryInjectable;
-import org.atmosphere.inject.BroadcasterIntrospector;
-import org.atmosphere.inject.InjectableObjectFactory;
-import org.atmosphere.inject.MetaBroadcasterInjectable;
-import org.atmosphere.inject.PathParamIntrospector;
-import org.atmosphere.inject.PostConstructIntrospector;
-import org.atmosphere.inject.WebSocketFactoryInjectable;
-import org.atmosphere.config.managed.AtmosphereHandlerServiceInterceptor;
-import org.atmosphere.pool.BoundedApachePoolableProvider;
-import org.atmosphere.pool.UnboundedApachePoolableProvider;
-import org.atmosphere.interceptor.AndroidAtmosphereInterceptor;
-import org.atmosphere.interceptor.CacheHeadersInterceptor;
-import org.atmosphere.interceptor.CorsInterceptor;
-import org.atmosphere.interceptor.HeartbeatInterceptor;
-import org.atmosphere.interceptor.IdleResourceInterceptor;
-import org.atmosphere.interceptor.JavaScriptProtocol;
-import org.atmosphere.interceptor.OnDisconnectInterceptor;
-import org.atmosphere.interceptor.PaddingAtmosphereInterceptor;
-import org.atmosphere.interceptor.SSEAtmosphereInterceptor;
-import org.atmosphere.interceptor.SuspendTrackerInterceptor;
-import org.atmosphere.interceptor.WebSocketMessageSuspendInterceptor;
-import org.atmosphere.websocket.DefaultWebSocketFactory;
-import org.atmosphere.websocket.DefaultWebSocketProcessor;
-import org.atmosphere.websocket.protocol.SimpleHttpProtocol;
+import org.atmosphere.cpr.AtmosphereReflectiveTypes;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.aot.hint.RuntimeHints;
@@ -78,33 +36,6 @@ public class AtmosphereRuntimeHints implements RuntimeHintsRegistrar {
             MemberCategory.ACCESS_DECLARED_FIELDS
     };
 
-    private static final String ANNOTATION_PKG = "org.atmosphere.annotation.";
-
-    private static final String[] ANNOTATION_PROCESSORS = {
-            "AsyncSupportListenerServiceProcessor",
-            "AsyncSupportServiceProcessor",
-            "AtmosphereFrameworkServiceProcessor",
-            "AtmosphereHandlerServiceProcessor",
-            "AtmosphereInterceptorServiceProcessor",
-            "AtmosphereResourceFactoryServiceProcessor",
-            "AtmosphereResourceListenerServiceProcessor",
-            "AtmosphereServiceProcessor",
-            "BroadcastFilterServiceProcessor",
-            "BroadcasterCacheInspectorServiceProcessor",
-            "BroadcasterCacheListenererviceProcessor",
-            "BroadcasterCacheServiceProcessor",
-            "BroadcasterFactoryServiceProcessor",
-            "BroadcasterListenerServiceProcessor",
-            "BroadcasterServiceProcessor",
-            "EndpointMapperServiceProcessor",
-            "ManagedServiceProcessor",
-            "UUIDProviderServiceProcessor",
-            "WebSocketFactoryServiceProcessor",
-            "WebSocketHandlerServiceProcessor",
-            "WebSocketProcessorServiceProcessor",
-            "WebSocketProtocolServiceProcessor"
-    };
-
     @Override
     public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
         ReflectionHints reflection = hints.reflection();
@@ -112,81 +43,26 @@ public class AtmosphereRuntimeHints implements RuntimeHintsRegistrar {
         // Spring-specific
         registerType(reflection, SpringAtmosphereObjectFactory.class);
 
-        // Injectable SPI implementations
-        registerType(reflection, AtmosphereConfigInjectable.class);
-        registerType(reflection, AtmosphereFrameworkInjectable.class);
-        registerType(reflection, AtmosphereResourceFactoryInjectable.class);
-        registerType(reflection, AtmosphereResourceSessionFactoryInjectable.class);
-        registerType(reflection, BroadcasterFactoryInjectable.class);
-        registerType(reflection, MetaBroadcasterInjectable.class);
-        registerType(reflection, WebSocketFactoryInjectable.class);
-        registerType(reflection, PostConstructIntrospector.class);
-        registerType(reflection, BroadcasterIntrospector.class);
-        registerType(reflection, AtmosphereResourceIntrospector.class);
-        registerType(reflection, AtmosphereRequestIntrospector.class);
-        registerType(reflection, AtmosphereResponseIntrospector.class);
-        registerType(reflection, AtmosphereResourceEventIntrospector.class);
-        registerType(reflection, PathParamIntrospector.class);
-
-        // Core reflective
-        registerType(reflection, AtmosphereResourceImpl.class);
-        registerType(reflection, AtmosphereRequestImpl.class);
-        registerType(reflection, AtmosphereResponseImpl.class);
-        registerType(reflection, ManagedAtmosphereHandler.class);
-        registerType(reflection, AtmosphereHandlerServiceInterceptor.class);
-        registerTypeByName(reflection,
-                "org.atmosphere.cpr.DefaultAtmosphereObjectFactory");
-        registerType(reflection, InjectableObjectFactory.class);
-        registerType(reflection, AtmosphereProducers.class);
-
-        // Framework infrastructure
-        registerType(reflection, AtmosphereFramework.class);
-        registerType(reflection, DefaultBroadcaster.class);
-        registerType(reflection, DefaultBroadcasterFactory.class);
-        registerType(reflection, DefaultAtmosphereResourceFactory.class);
-        registerType(reflection, DefaultMetaBroadcaster.class);
-        registerType(reflection, DefaultAtmosphereResourceSessionFactory.class);
-        registerType(reflection, SimpleHttpProtocol.class);
-
-        // AsyncSupport
-        registerTypeByName(reflection, "org.atmosphere.container.JSR356AsyncSupport");
-        registerTypeByName(reflection, "org.atmosphere.container.Servlet30CometSupport");
+        // Core Atmosphere types (source of truth: AtmosphereReflectiveTypes)
+        for (String typeName : AtmosphereReflectiveTypes.coreTypes()) {
+            registerTypeByName(reflection, typeName);
+        }
 
         // Pool implementations (only if commons-pool2 is on the classpath)
         if (classLoader != null) {
             try {
                 classLoader.loadClass("org.apache.commons.pool2.PooledObjectFactory");
-                registerType(reflection, UnboundedApachePoolableProvider.class);
-                registerType(reflection, BoundedApachePoolableProvider.class);
+                for (String typeName : AtmosphereReflectiveTypes.poolTypes()) {
+                    registerTypeByName(reflection, typeName);
+                }
             } catch (ClassNotFoundException ignored) {
                 // commons-pool2 not available; skip pool class registration
             }
         }
 
-        // Default interceptors (loaded by name via IOUtils.loadClass)
-        registerType(reflection, CorsInterceptor.class);
-        registerType(reflection, CacheHeadersInterceptor.class);
-        registerType(reflection, PaddingAtmosphereInterceptor.class);
-        registerType(reflection, AndroidAtmosphereInterceptor.class);
-        registerType(reflection, HeartbeatInterceptor.class);
-        registerType(reflection, SSEAtmosphereInterceptor.class);
-        registerType(reflection, JavaScriptProtocol.class);
-        registerType(reflection, WebSocketMessageSuspendInterceptor.class);
-        registerType(reflection, OnDisconnectInterceptor.class);
-        registerType(reflection, IdleResourceInterceptor.class);
-        registerType(reflection, SuspendTrackerInterceptor.class);
-
-        // Annotation processor
-        registerTypeByName(reflection, "org.atmosphere.cpr.DefaultAnnotationProcessor");
-
-        // WebSocket
-        registerType(reflection, DefaultWebSocketProcessor.class);
-        registerType(reflection, DefaultWebSocketFactory.class);
-        registerTypeByName(reflection, "org.atmosphere.container.JSR356Endpoint");
-
         // Annotation processors (instantiated reflectively by AnnotationHandler)
-        for (String processor : ANNOTATION_PROCESSORS) {
-            registerTypeByName(reflection, ANNOTATION_PKG + processor);
+        for (String processor : AtmosphereReflectiveTypes.annotationProcessors()) {
+            registerTypeByName(reflection, processor);
         }
 
         // ServiceLoader resource files

--- a/modules/spring-boot-starter/src/main/java/org/atmosphere/spring/boot/DurableSessionAutoConfiguration.java
+++ b/modules/spring-boot-starter/src/main/java/org/atmosphere/spring/boot/DurableSessionAutoConfiguration.java
@@ -15,8 +15,6 @@
  */
 package org.atmosphere.spring.boot;
 
-import java.time.Duration;
-
 import org.atmosphere.cpr.AtmosphereFramework;
 import org.atmosphere.session.DurableSessionInterceptor;
 import org.atmosphere.session.InMemorySessionStore;
@@ -62,8 +60,8 @@ public class DurableSessionAutoConfiguration {
             AtmosphereFramework framework,
             AtmosphereProperties properties) {
         var dsProps = properties.getDurableSessions();
-        var ttl = Duration.ofMinutes(dsProps.getSessionTtlMinutes());
-        var cleanup = Duration.ofSeconds(dsProps.getCleanupIntervalSeconds());
+        var ttl = dsProps.getSessionTtl();
+        var cleanup = dsProps.getCleanupInterval();
 
         var interceptor = new DurableSessionInterceptor(store, ttl, cleanup);
         framework.interceptor(interceptor);

--- a/modules/spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/modules/spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -45,9 +45,9 @@
       "description": "Whether to enable WebSocket transport support."
     },
     {
-      "name": "atmosphere.heartbeat-interval-in-seconds",
-      "type": "java.lang.Integer",
-      "description": "Heartbeat interval in seconds for keeping connections alive."
+      "name": "atmosphere.heartbeat-interval",
+      "type": "java.time.Duration",
+      "description": "Heartbeat interval for keeping connections alive. Defaults to seconds if no unit suffix is specified (e.g. '30' means 30s)."
     },
     {
       "name": "atmosphere.init-params",
@@ -61,16 +61,16 @@
       "defaultValue": false
     },
     {
-      "name": "atmosphere.durable-sessions.session-ttl-minutes",
-      "type": "java.lang.Long",
-      "description": "Time-to-live for durable sessions in minutes.",
-      "defaultValue": 1440
+      "name": "atmosphere.durable-sessions.session-ttl",
+      "type": "java.time.Duration",
+      "description": "Time-to-live for durable sessions. Defaults to minutes if no unit suffix is specified (e.g. '1440' means 1440 minutes).",
+      "defaultValue": "1440m"
     },
     {
-      "name": "atmosphere.durable-sessions.cleanup-interval-seconds",
-      "type": "java.lang.Long",
-      "description": "Interval in seconds between expired session cleanup runs.",
-      "defaultValue": 60
+      "name": "atmosphere.durable-sessions.cleanup-interval",
+      "type": "java.time.Duration",
+      "description": "Interval between expired session cleanup runs. Defaults to seconds if no unit suffix is specified (e.g. '60' means 60s).",
+      "defaultValue": "60s"
     },
     {
       "name": "atmosphere.grpc.enabled",

--- a/samples/spring-boot-durable-sessions/src/main/resources/application.properties
+++ b/samples/spring-boot-durable-sessions/src/main/resources/application.properties
@@ -6,5 +6,5 @@ atmosphere.servlet-path=/atmosphere/*
 
 # Enable durable sessions — survive server restarts
 atmosphere.durable-sessions.enabled=true
-atmosphere.durable-sessions.session-ttl-minutes=1440
-atmosphere.durable-sessions.cleanup-interval-seconds=60
+atmosphere.durable-sessions.session-ttl=1440m
+atmosphere.durable-sessions.cleanup-interval=60s


### PR DESCRIPTION
## Summary

Comprehensive JDK 21 modernization of Atmosphere core, framework integrations, and TypeScript client:

- **Records & sealed types**: `Action` → immutable record; `Body` → sealed interface with `StringBody`/`BytesBody`/`EmptyBody` records; `AtmosphereResourceImpl` state → `AtomicReference<LifecycleState>` replacing 6 AtomicBooleans
- **God class decomposition**: `AtmosphereFramework.init()` → `FrameworkBootstrap` (7 named phases); `DefaultBroadcaster` → extracted `BroadcasterLifecycle` + `BroadcasterMembership`; `AtmosphereResponseImpl` I/O → `ResponseWriter`; `AtmosphereRequestImpl` inner classes → top-level `NoOpsRequest`, `InputStreamServletAdapter`, `ByteArrayServletInputStream`
- **Centralized registries**: `AtmosphereAnnotations` and `AtmosphereReflectiveTypes` eliminate cross-module duplication in Spring Boot and Quarkus extensions
- **Bug fixes**: `readerSet.getAndSet(false)` → `getAndSet(true)`; `getHeaders()` returning `null` → `Collections.emptyList()`; `setStatus()` sync gap; `FrameworkDiagnostics` lexicographic → semver version comparison; `ContainerPatcher` isolates `System.setProperty` with opt-out
- **Interface cleanup**: ~70 redundant `HttpServletRequest`/`HttpServletResponse` re-declarations removed from `AtmosphereRequest`/`AtmosphereResponse`
- **Integration updates**: Spring Boot `Duration` properties; Quarkus `Duration` config; GrpcProcessor adapted to Action record API
- **Client (atmosphere.js)**: version desync fixed (hardcoded `'5.0.0'` → imported `VERSION`); shared `useAtmosphereCore` hook eliminates React/RN duplication; manual controls (disconnect, suspend, resume) added

49 files changed, 2869 insertions, 2452 deletions.

## Test plan

- [x] Full `./mvnw compile` — zero warnings across all modules
- [x] Architectural validation passed
- [ ] CI: full `./mvnw install` with tests
- [ ] atmosphere.js: `npm test` (323 tests)