### PR TITLE
feat(ai): add LiteLLM proxy quick factory to OpenAiCompatibleClient

### DIFF
--- a/modules/ai/README.md
+++ b/modules/ai/README.md
@@ -1,6 +1,6 @@
 # Atmosphere AI
 
-AI/LLM streaming module for Atmosphere. Provides `@AiEndpoint`, `@Prompt`, `@AiTool`, `StreamingSession`, the `AgentRuntime` SPI for auto-detected AI framework adapters, and a built-in `OpenAiCompatibleClient` that works with Gemini, OpenAI, Ollama, and any OpenAI-compatible API — including tool calling, structured output, and usage metadata tracking.
+AI/LLM streaming module for Atmosphere. Provides `@AiEndpoint`, `@Prompt`, `@AiTool`, `StreamingSession`, the `AgentRuntime` SPI for auto-detected AI framework adapters, and a built-in `OpenAiCompatibleClient` that works with Gemini, OpenAI, Ollama, a LiteLLM proxy, and any OpenAI-compatible API — including tool calling, structured output, and usage metadata tracking.
 
 ## Maven Coordinates
 

--- a/modules/ai/src/main/java/org/atmosphere/ai/llm/OpenAiCompatibleClient.java
+++ b/modules/ai/src/main/java/org/atmosphere/ai/llm/OpenAiCompatibleClient.java
@@ -199,6 +199,36 @@ public class OpenAiCompatibleClient implements LlmClient {
                 .build();
     }
 
+    /**
+     * Quick factory for a local LiteLLM proxy on its default port
+     * ({@code http://localhost:4000/v1}). LiteLLM exposes an
+     * OpenAI-compatible endpoint that fronts many upstream providers behind a
+     * single gateway, so it reuses this client unchanged.
+     *
+     * @param apiKey the LiteLLM proxy virtual/master key; may be {@code null}
+     *               for an unsecured local proxy
+     */
+    public static OpenAiCompatibleClient litellm(String apiKey) {
+        return litellm("http://localhost:4000/v1", apiKey);
+    }
+
+    /**
+     * Quick factory for a LiteLLM proxy at an explicit base URL. Point
+     * {@code baseUrl} at the proxy's OpenAI-compatible endpoint (typically
+     * ending in {@code /v1}).
+     *
+     * @param baseUrl the LiteLLM proxy base URL, e.g.
+     *                {@code https://litellm.internal.example.com/v1}
+     * @param apiKey  the LiteLLM proxy virtual/master key; may be {@code null}
+     *                for an unsecured proxy
+     */
+    public static OpenAiCompatibleClient litellm(String baseUrl, String apiKey) {
+        return builder()
+                .baseUrl(baseUrl)
+                .apiKey(apiKey)
+                .build();
+    }
+
     @Override
     public void streamChatCompletion(ChatCompletionRequest request, StreamingSession session) {
         streamChatCompletion(request, session, null, null);

--- a/modules/ai/src/test/java/org/atmosphere/ai/llm/OpenAiCompatibleClientTest.java
+++ b/modules/ai/src/test/java/org/atmosphere/ai/llm/OpenAiCompatibleClientTest.java
@@ -1181,6 +1181,44 @@ public class OpenAiCompatibleClientTest {
     }
 
     @Test
+    public void testLiteLlmFactory() {
+        var client = OpenAiCompatibleClient.litellm("https://litellm.example.com/v1", "proxy-key");
+        assertNotNull(client);
+        assertEquals("proxy-key", client.apiKey());
+    }
+
+    @Test
+    public void testLiteLlmFactoryDefaultBaseUrl() {
+        var client = OpenAiCompatibleClient.litellm("proxy-key");
+        assertNotNull(client);
+        assertEquals("proxy-key", client.apiKey());
+    }
+
+    @Test
+    public void testLiteLlmFactoryTargetsConfiguredBaseUrl() throws Exception {
+        var httpClient = mockHttpClient(200, "data: [DONE]\n\n");
+        // The litellm() factory must send requests to the proxy base URL with
+        // the proxy key as a bearer token — the same wire contract as any other
+        // OpenAI-compatible endpoint.
+        var client = OpenAiCompatibleClient.builder()
+                .baseUrl("https://litellm.example.com/v1")
+                .apiKey("proxy-key")
+                .httpClient(httpClient)
+                .build();
+
+        var session = StreamingSessions.start("litellm-base-url", resource);
+        var request = ChatCompletionRequest.of("gpt-4o", "ping");
+        client.streamChatCompletion(request, session);
+
+        var captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(captor.capture(), any(HttpResponse.BodyHandler.class));
+        var sent = captor.getValue();
+        assertEquals("https://litellm.example.com/v1/chat/completions", sent.uri().toString());
+        assertEquals(java.util.List.of("Bearer proxy-key"),
+                sent.headers().allValues("Authorization"));
+    }
+
+    @Test
     public void testCustomHeadersReachTheWire() throws Exception {
         var httpClient = mockHttpClient(200, "data: [DONE]\n\n");
         var client = OpenAiCompatibleClient.builder()


### PR DESCRIPTION
## Summary

Adds a `litellm()` quick factory to `OpenAiCompatibleClient`, alongside the existing `openai()`, `gemini()`, and `ollama()` factories. LiteLLM exposes an OpenAI-compatible proxy that fronts many upstream providers (OpenAI, Anthropic, Bedrock, Vertex, Azure, Gemini, Groq, ...) behind one gateway, so it reuses the built-in client unchanged.

## Changes

- `modules/ai/src/main/java/org/atmosphere/ai/llm/OpenAiCompatibleClient.java`
  - `litellm(String apiKey)` — targets a local LiteLLM proxy on its default port (`http://localhost:4000/v1`), mirroring how `ollama()` encodes its default port.
  - `litellm(String baseUrl, String apiKey)` — targets a LiteLLM proxy at an explicit base URL. `apiKey` (the proxy virtual/master key) may be `null` for an unsecured proxy.
- `modules/ai/src/test/java/org/atmosphere/ai/llm/OpenAiCompatibleClientTest.java` — factory coverage: non-null construction, apiKey wiring, and a wire-level assertion that requests reach the configured base URL with the proxy key as a bearer token.
- `modules/ai/README.md` — the module intro now lists a LiteLLM proxy among the supported OpenAI-compatible endpoints.

## Design

Both factories are thin wrappers over the existing `builder()`, identical in shape to `gemini()` / `openai()`. No new dependencies, no changes to the request/stream/tool-loop paths — a LiteLLM proxy is just another OpenAI-compatible base URL. The value over `builder().baseUrl(...).build()` is the same as the other quick factories: discoverability and an encoded default endpoint (`localhost:4000/v1`).

## Tests

**Module build (zero-warning gate + Checkstyle + PMD):**
```
$ ./mvnw install -pl modules/ai -am -DskipTests
atmosphere-project ... SUCCESS
atmosphere-runtime ... SUCCESS
atmosphere-ai ....... SUCCESS
BUILD SUCCESS
```

**Unit tests:**
```
$ ./mvnw test -pl modules/ai -Dtest=OpenAiCompatibleClientTest
Tests run: 43, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
(includes `testLiteLlmFactory`, `testLiteLlmFactoryDefaultBaseUrl`, `testLiteLlmFactoryTargetsConfiguredBaseUrl`)

**Live end-to-end through a real LiteLLM proxy:**

A LiteLLM proxy (alias `e2e-gpt` → a live Azure OpenAI GPT deployment) was driven through the client's streaming path. `OpenAiCompatibleClient` streamed a real completion end-to-end:
```
[litellm E2E] meta ai.model=e2e-gpt
[litellm E2E] response: 4
```
This exercised the full chain: `OpenAiCompatibleClient` → LiteLLM proxy → upstream provider → SSE parsed back through `StreamingSession`. (The local plaintext proxy required forcing the JDK client to HTTP/1.1, since uvicorn rejects HTTP/2 h2c upgrade over plaintext; production LiteLLM behind HTTPS negotiates HTTP/2 via ALPN like the other factories.)

## Example usage

```java
// Local LiteLLM proxy on the default port:
var client = OpenAiCompatibleClient.litellm(System.getenv("LITELLM_API_KEY"));

// Explicit proxy URL:
var client = OpenAiCompatibleClient.litellm(
        "https://litellm.internal.example.com/v1",
        System.getenv("LITELLM_API_KEY"));
```

## Risk / compatibility

- Additive only. No existing factory or request path changes.
- No new dependencies.
